### PR TITLE
network: fix header issue where content-type was duplicated

### DIFF
--- a/processout-sdk/src/main/java/com/processout/processout_sdk/Network.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/Network.java
@@ -86,7 +86,6 @@ class Network {
             @Override
             public Map<String, String> getHeaders() {
                 Map<String, String> headers = new HashMap<>();
-                headers.put("Content-Type", "application/json");
                 headers.put("Authorization", "Basic " + Base64.encodeToString((projectId + ":").getBytes(), Base64.NO_WRAP));
                 return headers;
             }


### PR DESCRIPTION
Volley was already sending the correct content-type header.
Specifying the same header ended up duplicating them in the request.