### PR TITLE
SDK: Change context parameters to support DI setups

### DIFF
--- a/app/src/main/java/com/processout/processoutexample/MainActivity.java
+++ b/app/src/main/java/com/processout/processoutexample/MainActivity.java
@@ -1,5 +1,6 @@
 package com.processout.processoutexample;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -64,6 +65,7 @@ public class MainActivity extends AppCompatActivity {
     public void initiatePayment() {
         final ProcessOut p = new ProcessOut(this, "test-proj_gAO1Uu0ysZJvDuUpOGPkUBeE3pGalk3x");
         Card c = new Card("4000000000000259", 10, 20, "737");
+        final Activity with = this;
         p.tokenize(c, null, new TokenCallback() {
             @Override
             public void onError(Exception error) {
@@ -82,7 +84,7 @@ public class MainActivity extends AppCompatActivity {
                     public void onError(Exception error) {
                         Log.e("PROCESSOUT", error.toString());
                     }
-                }));
+                }), with);
             }
         });
     }

--- a/processout-sdk/src/androidTest/java/com/processout/processout_sdk/ProcessOutTest.java
+++ b/processout-sdk/src/androidTest/java/com/processout/processout_sdk/ProcessOutTest.java
@@ -1,5 +1,7 @@
 package com.processout.processout_sdk;
 
+import android.app.Activity;
+import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.util.Log;
 
@@ -21,6 +23,7 @@ public class ProcessOutTest {
     private String privateKey = "key_sandbox_mah31RDFqcDxmaS7MvhDbJfDJvjtsFTB";
     final private ProcessOut p = new ProcessOut(InstrumentationRegistry.getContext(), projectId);
     private Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+    final Context withActivity = InstrumentationRegistry.getContext();
 
     @Test
     public void threeDS2Fingerprint() {
@@ -73,7 +76,7 @@ public class ProcessOutTest {
                                     public void onError(Exception error) {
                                         fail("ThreeDS2 failed");
                                     }
-                                });
+                                }, withActivity);
                             } catch (JSONException e) {
                                 fail("Unhandled exception");
                                 e.printStackTrace();
@@ -145,7 +148,7 @@ public class ProcessOutTest {
                                     public void onError(Exception error) {
                                         fail("ThreeDS2 failed" + error.toString());
                                     }
-                                });
+                                }, withActivity);
                             } catch (JSONException e) {
                                 fail("Unhandled exception");
                                 e.printStackTrace();


### PR DESCRIPTION
Previously the context used to start a new activity was passed during the `ProcessOut` object instantiation. 
This context was used to handle the networking queue, to instantiate a new Activity when a Web redirection was needed and also to display a hidden webview when performing a web fingerprinting.

This caused some issues when dealing with Dependency Injection as the context wasn't an `Activity` but rather an `ApplicationContext` with which we can't be adding views directly.

The solution is to follow the same flow as the iOS SDK by passing the current Activity context to the `makeCardPayment` method. We however still keep the `ApplicationContext` passed during the SDK instantiation as we will use this one to handle the networking.