### PR TITLE
Add support for makeCardToken method + WebViews challenges

### DIFF
--- a/app/src/main/java/com/processout/processoutexample/MainActivity.java
+++ b/app/src/main/java/com/processout/processoutexample/MainActivity.java
@@ -51,7 +51,7 @@ public class MainActivity extends AppCompatActivity {
 
             @Override
             public void onSuccess(String token) {
-                p.makeCardPayment("iv_OSC3heaP1zR7ywLc4GrebqxqHRTuXqG8", token, ProcessOut.createDefaultTestHandler(MainActivity.this, new ProcessOut.ThreeDSHandlerTestCallback() {
+                p.makeCardPayment("invoiceId", token, ProcessOut.createDefaultTestHandler(MainActivity.this, new ProcessOut.ThreeDSHandlerTestCallback() {
                     @Override
                     public void onSuccess(String invoiceId) {
                         Log.d("PROCESSOUT", "invoice: " + invoiceId);

--- a/app/src/main/java/com/processout/processoutexample/MainActivity.java
+++ b/app/src/main/java/com/processout/processoutexample/MainActivity.java
@@ -29,14 +29,15 @@ public class MainActivity extends AppCompatActivity {
 
         Intent intent = getIntent();
         Uri data = intent.getData();
-        if (data == null)
+        if (data == null) {
             this.initiatePayment();
-        else {
-            // Check if the activity has been opened from ProcessOut
-            String gatewayToken = ProcessOut.handleURLCallback(data);
-            if (gatewayToken != null)
-                Log.d("PROCESSOUT", gatewayToken); // Send the token to backend
+            return;
         }
+
+        // Check if the activity has been opened from ProcessOut
+        String gatewayToken = ProcessOut.handleURLCallback(data);
+        if (gatewayToken != null)
+            Log.d("PROCESSOUT", gatewayToken); // Send the token to backend
     }
 
     public void initiatePayment() {

--- a/app/src/main/java/com/processout/processoutexample/MainActivity.java
+++ b/app/src/main/java/com/processout/processoutexample/MainActivity.java
@@ -9,11 +9,15 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import com.processout.processout_sdk.AlternativeGateway;
 import com.processout.processout_sdk.Card;
+import com.processout.processout_sdk.ListAlternativeMethodsCallback;
 import com.processout.processout_sdk.ProcessOut;
 import com.processout.processout_sdk.ThreeDSVerificationCallback;
 import com.processout.processout_sdk.TokenCallback;
 import com.processout.processout_sdk.WebViewReturnAction;
+
+import java.util.ArrayList;
 
 
 public class MainActivity extends AppCompatActivity {
@@ -29,42 +33,15 @@ public class MainActivity extends AppCompatActivity {
             this.initiatePayment();
         else {
             // Check if the activity has been opened from ProcessOut
-            WebViewReturnAction returnAction = ProcessOut.handleProcessOutReturn(data);
-            if (returnAction == null) {
-                // Opening URI is not from ProcessOut
-            } else {
-                switch (returnAction.getType()) {
-                    case APMAuthorization:
-                        // Value contains the APM token
-                        if (returnAction.isSuccess())
-                            Log.d("PROCESSOUT", returnAction.getValue());
-                        break;
-                    case ThreeDSVerification:
-                        // Value contains the invoice_id
-                        if (returnAction.isSuccess())
-                            Log.d("PROCESSOUT", returnAction.getValue());
-                        break;
-                    case ThreeDSFallbackVerification:
-                        new ProcessOut(this, "test-proj_gAO1Uu0ysZJvDuUpOGPkUBeE3pGalk3x").continueThreeDSVerification(returnAction.getInvoiceId(), returnAction.getValue(), new ThreeDSVerificationCallback() {
-                            @Override
-                            public void onSuccess(String invoiceId) {
-                                Log.d("PROCESSOUT", invoiceId);
-                            }
-
-                            @Override
-                            public void onError(Exception error) {
-                                Log.d("PROCESSOUT",  error.toString());
-                            }
-                        });
-                        break;
-                }
-            }
+            String gatewayToken = ProcessOut.handleURLCallback(data);
+            if (gatewayToken != null)
+                Log.d("PROCESSOUT", gatewayToken); // Send the token to backend
         }
     }
 
     public void initiatePayment() {
         final ProcessOut p = new ProcessOut(this, "test-proj_gAO1Uu0ysZJvDuUpOGPkUBeE3pGalk3x");
-        Card c = new Card("4000000000000259", 10, 20, "737");
+        Card c = new Card("4000000000003253", 10, 20, "737");
         final Activity with = this;
         p.tokenize(c, null, new TokenCallback() {
             @Override
@@ -74,7 +51,7 @@ public class MainActivity extends AppCompatActivity {
 
             @Override
             public void onSuccess(String token) {
-                p.makeCardPayment("invoiceId", token, ProcessOut.createDefaultTestHandler(MainActivity.this, new ProcessOut.ThreeDSHandlerTestCallback() {
+                p.makeCardPayment("iv_OSC3heaP1zR7ywLc4GrebqxqHRTuXqG8", token, ProcessOut.createDefaultTestHandler(MainActivity.this, new ProcessOut.ThreeDSHandlerTestCallback() {
                     @Override
                     public void onSuccess(String invoiceId) {
                         Log.d("PROCESSOUT", "invoice: " + invoiceId);

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/AlternativeGateway.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/AlternativeGateway.java
@@ -3,8 +3,7 @@ package com.processout.processout_sdk;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.webkit.WebSettings;
-import android.webkit.WebView;
+import android.support.annotation.NonNull;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -24,14 +23,8 @@ public class AlternativeGateway {
     private String projectId;
     private Context context;
 
-    /**
-     *
-     */
     public void redirect() {
-        WebView theWebPage = new WebView(this.context);
-        theWebPage.getSettings().setJavaScriptEnabled(true);
-        theWebPage.getSettings().setPluginState(WebSettings.PluginState.ON);
-        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(Network.CHECKOUT_URL + this.projectId + "/" + this.invoiceId + "/redirect/" + this.id));
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(Network.CHECKOUT_URL + "/" + this.projectId + "/" + this.invoiceId + "/redirect/" + this.id));
         this.context.startActivity(browserIntent);
     }
 

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/CustomerAction.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/CustomerAction.java
@@ -16,10 +16,7 @@ class CustomerAction {
         @SerializedName("fingerprint")
         FINGERPRINT
     }
-
-    ;
-
-
+    
     @SerializedName("type")
     private CustomerActionType type;
     @SerializedName("value")

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/CustomerAction.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/CustomerAction.java
@@ -15,7 +15,9 @@ class CustomerAction {
         REDIRECT,
         @SerializedName("fingerprint")
         FINGERPRINT
-    };
+    }
+
+    ;
 
 
     @SerializedName("type")

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/CustomerActionHandler.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/CustomerActionHandler.java
@@ -1,0 +1,168 @@
+package com.processout.processout_sdk;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Handler;
+import android.util.Base64;
+import android.view.ViewGroup;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import android.widget.FrameLayout;
+
+import com.google.gson.Gson;
+import com.processout.processout_sdk.POWebViews.ProcessOutWebView;
+import com.processout.processout_sdk.POWebViews.WebViewCallback;
+import com.processout.processout_sdk.ProcessOutExceptions.ProcessOutException;
+import com.processout.processout_sdk.ProcessOutExceptions.ProcessOutWebException;
+
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+class CustomerActionHandler {
+    private ThreeDSHandler handler;
+    private Context with;
+    private CustomerActionCallback callback;
+    private Gson gson = new Gson();
+    private ProcessOutWebView processOutWebView;
+
+    private final String ThreeDS2ChallengeSuccess = "gway_req_eyJib2R5Ijoie1widHJhbnNTdGF0dXNcIjpcIllcIn0ifQ==";
+    private final String ThreeDS2ChallengeError = "gway_req_eyJib2R5Ijoie1widHJhbnNTdGF0dXNcIjpcIk5cIn0ifQ==";
+
+    public interface CustomerActionCallback {
+        void shouldContinue(String source);
+    }
+
+    CustomerActionHandler(ThreeDSHandler handler, ProcessOutWebView processOutWebView, Context with, final CustomerActionCallback callback) {
+        this.handler = handler;
+        this.with = with;
+        this.callback = callback;
+        this.processOutWebView = processOutWebView;
+    }
+
+    void handleCustomerAction(CustomerAction customerAction) {
+        switch (customerAction.getType()) {
+            case FINGERPRINT_MOBILE:
+                DirectoryServerData directoryServerData = gson.fromJson(
+                        new String(Base64.decode(customerAction.getValue().getBytes(), Base64.NO_WRAP)), DirectoryServerData.class);
+                handler.doFingerprint(directoryServerData, new ThreeDSHandler.DoFingerprintCallback() {
+                    @Override
+                    public void continueCallback(ThreeDSFingerprintResponse request) {
+                        MiscGatewayRequest gwayRequest = new MiscGatewayRequest(gson.toJson(request, ThreeDSFingerprintResponse.class));
+                        String jsonRequest = Base64.encodeToString(gson.toJson(gwayRequest, MiscGatewayRequest.class).getBytes(), Base64.NO_WRAP);
+                        callback.shouldContinue("gway_req_" + jsonRequest);
+                    }
+                });
+                break;
+            case CHALLENGE_MOBILE:
+                AuthenticationChallengeData authentificationData = gson.fromJson
+                        (new String(Base64.decode(customerAction.getValue().getBytes(), Base64.NO_WRAP)), AuthenticationChallengeData.class);
+                handler.doChallenge(authentificationData, new ThreeDSHandler.DoChallengeCallback() {
+                    @Override
+                    public void success() {
+                        callback.shouldContinue(ThreeDS2ChallengeSuccess);
+                    }
+
+                    @Override
+                    public void error() {
+                        callback.shouldContinue(ThreeDS2ChallengeError);
+                    }
+                });
+                break;
+            case REDIRECT:
+            case URL:
+                processOutWebView.setCallback(new WebViewCallback() {
+                    @Override
+                    public void onResult(String token) {
+                        callback.shouldContinue(token);
+                    }
+
+                    @Override
+                    public void onAuthenticationError() {
+                        handler.onError(new ProcessOutWebException("Web authentication failed"));
+                    }
+                });
+                handler.doPresentWebView(processOutWebView);
+                processOutWebView.loadUrl(customerAction.getValue());
+                break;
+            case FINGERPRINT:
+                FrameLayout rootLayout = ((Activity) (with)).findViewById(android.R.id.content);
+
+                // Building the possibly needed webView
+                final WebView FingerprintWebView = new WebView(this.with);
+                FingerprintWebView.getSettings().setUserAgentString("ProcessOut Android-Webview/" + ProcessOut.SDK_VERSION);
+                FingerprintWebView.getSettings().setJavaScriptEnabled(true); // enable javascript
+
+                // Defining fallback request in case the fingerprint times out or is unavailable
+                final MiscGatewayRequest fallbackGwayRequest = new MiscGatewayRequest("{\"threeDS2FingerprintTimeout\":true}");
+                fallbackGwayRequest.setURL(customerAction.getValue());
+                HashMap<String, String> fallbackHeaders = new HashMap<String, String>();
+                fallbackHeaders.put("Content-Type", "application/json");
+                fallbackGwayRequest.setHeaders(fallbackHeaders);
+
+                // Setup the timeout handler
+                final Handler timeOutHandler = new android.os.Handler();
+                // Configuring the action on timeout
+                final Runnable fingerprintTimeoutClearer = new Runnable() {
+                    @Override
+                    public void run() {
+                        // Destroying the webview
+                        destroyWebView(FingerprintWebView);
+                        callback.shouldContinue(fallbackGwayRequest.generateToken());
+                    }
+                };
+
+                // Catch webview URL redirects
+                FingerprintWebView.setWebViewClient(new WebViewClient() {
+                    @Override
+                    public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+                        // Check if the current Android version is supporte
+                        String token = null;
+
+                        // We cancel the timeout handler
+                        timeOutHandler.removeCallbacks(fingerprintTimeoutClearer);
+
+                        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+                            token = request.getUrl().getQueryParameter("token");
+                        }
+                        if (token == null) {
+                            // Android version not supported for fingerprinting
+                            token = fallbackGwayRequest.generateToken();
+                        }
+                        callback.shouldContinue(token);
+                        return super.shouldOverrideUrlLoading(view, request);
+                    }
+                });
+
+                // Start the timeout
+                timeOutHandler.postDelayed(fingerprintTimeoutClearer, TimeUnit.SECONDS.toMillis(10));
+
+                // Load the fingerprint URL
+                FingerprintWebView.loadUrl(customerAction.getValue());
+
+                // Add the webview to content
+                if (with instanceof Activity) {
+                    // We perform the fingerprint by displaying the hidden webview
+                    rootLayout.addView(FingerprintWebView);
+                } else {
+                    // We can't instantiate the webview so fallback to default fingerprinting value
+                    timeOutHandler.removeCallbacks(fingerprintTimeoutClearer);
+                    callback.shouldContinue(fallbackGwayRequest.generateToken());
+                }
+                break;
+            default:
+                handler.onError(new ProcessOutException("Unhandled threeDS action:" + customerAction.getType().name()));
+                break;
+        }
+    }
+
+    private void destroyWebView(WebView webView) {
+        // Preparing the webview removal
+        ((ViewGroup) webView.getParent()).removeView(webView);
+        webView.removeAllViews();
+        webView.clearHistory();
+        webView.clearCache(true);
+        webView.onPause();
+        webView.destroy();
+    }
+}

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/CvcUpdateCallback.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/CvcUpdateCallback.java
@@ -6,5 +6,6 @@ package com.processout.processout_sdk;
 
 public interface CvcUpdateCallback {
     public void onSuccess();
+
     public void onError(Exception error);
 }

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ListAlternativeMethodsCallback.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ListAlternativeMethodsCallback.java
@@ -4,5 +4,6 @@ import java.util.ArrayList;
 
 public interface ListAlternativeMethodsCallback {
     void onSuccess(ArrayList<AlternativeGateway> gateways);
+
     void onError(Exception e);
 }

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/Network.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/Network.java
@@ -40,7 +40,7 @@ class Network {
     private static String privateKey = "";
 
     private static final String API_URL = "https://api.processout.com";
-    private static final String CHECKOUT_URL = "https://checkout.processout.com";
+    protected static final String CHECKOUT_URL = "https://checkout.processout.com";
 
     private Network() {
     }

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/Network.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/Network.java
@@ -39,13 +39,15 @@ class Network {
     private static String projectId;
     private static String privateKey = "";
 
-    protected static final String API_URL = "https://api.processout.com";
-    protected static final String CHECKOUT_URL = "https://checkout.processout.com";
+    private static final String API_URL = "https://api.processout.com";
+    private static final String CHECKOUT_URL = "https://checkout.processout.com";
 
-    private Network() {}
+    private Network() {
+    }
 
     public interface NetworkResult {
         void onError(Exception error);
+
         void onSuccess(JSONObject json);
     }
 
@@ -63,9 +65,9 @@ class Network {
                 } else if (error instanceof AuthFailureError) {
                     callback.onError(new ProcessOutAuthException("Request not authorized"));
                 } else if (error instanceof ServerError) {
-                    if(error.networkResponse.data!=null) {
+                    if (error.networkResponse.data != null) {
                         try {
-                            String data = new String(error.networkResponse.data,"UTF-8");
+                            String data = new String(error.networkResponse.data, "UTF-8");
                             Gson g = new GsonBuilder()
                                     .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                                     .create();
@@ -83,7 +85,7 @@ class Network {
                     callback.onError(new ProcessOutException("Error while parsing server response"));
                 }
             }
-        }){
+        }) {
             @Override
             public Map<String, String> getHeaders() {
                 Map<String, String> headers = new HashMap<>();
@@ -129,7 +131,8 @@ class ErrorReponse {
     private String errorType;
 
     public ErrorReponse(String errorMessage, String errorCode) {
-        this.message = message;this.errorType = errorType;
+        this.message = message;
+        this.errorType = errorType;
     }
 
     public String getErrorMessage() {

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/POWebViews/CardTokenWebView.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/POWebViews/CardTokenWebView.java
@@ -1,0 +1,21 @@
+package com.processout.processout_sdk.POWebViews;
+
+import android.content.Context;
+import android.net.Uri;
+
+public class CardTokenWebView extends ProcessOutWebView {
+
+    public CardTokenWebView(Context context) {
+        super(context);
+    }
+
+    @Override
+    void onRedirect(Uri uri) {
+        // Configuring the webview
+        String token = uri.getQueryParameter("token");
+        if (token != null) {
+            // Destroying the webview
+            callback.onResult(token);
+        }
+    }
+}

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/POWebViews/PaymentWebView.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/POWebViews/PaymentWebView.java
@@ -1,0 +1,25 @@
+package com.processout.processout_sdk.POWebViews;
+
+import android.content.Context;
+import android.net.Uri;
+
+public class PaymentWebView extends ProcessOutWebView {
+
+    public PaymentWebView(Context context) {
+        super(context);
+    }
+
+    @Override
+    void onRedirect(Uri uri) {
+        // Configuring the webview
+        String token = uri.getQueryParameter("token");
+
+        if (token != null) {
+            // Destroying the webview
+            callback.onResult(token);
+            return;
+        }
+
+        callback.onAuthenticationError();
+    }
+}

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/POWebViews/ProcessOutWebView.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/POWebViews/ProcessOutWebView.java
@@ -1,0 +1,38 @@
+package com.processout.processout_sdk.POWebViews;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import com.processout.processout_sdk.ProcessOut;
+
+public abstract class ProcessOutWebView extends WebView {
+
+    final private String REDIRECT_URL_PATTERN = "https:\\/\\/checkout\\.processout\\.(ninja|com)\\/helpers\\/mobile-processout-webview-landing.*";
+    protected WebViewCallback callback;
+
+    public ProcessOutWebView(Context context) {
+        super(context);
+        this.getSettings().setUserAgentString("ProcessOut Android-Webview/" + ProcessOut.SDK_VERSION);
+        this.getSettings().setJavaScriptEnabled(true); // enable javascript
+
+        // Catch URL loading
+        final ProcessOutWebView instance = this;
+        setWebViewClient(new WebViewClient() {
+            @Override
+            public void onPageStarted(WebView view, String url, Bitmap favicon) {
+                if (url.matches(REDIRECT_URL_PATTERN))
+                    instance.onRedirect(Uri.parse(url));
+                super.onPageStarted(view, url, favicon);
+            }
+        });
+    }
+
+    public void setCallback(WebViewCallback callback) {
+        this.callback = callback;
+    }
+
+    abstract void onRedirect(Uri uri);
+}

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/POWebViews/WebViewCallback.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/POWebViews/WebViewCallback.java
@@ -1,0 +1,7 @@
+package com.processout.processout_sdk.POWebViews;
+
+public interface WebViewCallback {
+    void onResult(String token);
+
+    void onAuthenticationError();
+}

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 
 public class ProcessOut {
 
-    public static final String SDK_VERSION = "v2.9.2";
+    public static final String SDK_VERSION = "v2.10.0";
 
     private String projectId;
     private Context context;

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOutExceptions/ProcessOutAuthException.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOutExceptions/ProcessOutAuthException.java
@@ -4,7 +4,7 @@ package com.processout.processout_sdk.ProcessOutExceptions;
  * Created by jeremylejoux on 11/18/18.
  */
 
-public class ProcessOutAuthException extends ProcessOutException{
+public class ProcessOutAuthException extends ProcessOutException {
 
     public ProcessOutAuthException(String message) {
         super(message);

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOutExceptions/ProcessOutCardException.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOutExceptions/ProcessOutCardException.java
@@ -4,7 +4,7 @@ package com.processout.processout_sdk.ProcessOutExceptions;
  * Created by jeremylejoux on 11/18/18.
  */
 
-public class ProcessOutCardException  extends ProcessOutException{
+public class ProcessOutCardException extends ProcessOutException {
 
     private String code;
 

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOutExceptions/ProcessOutWebException.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOutExceptions/ProcessOutWebException.java
@@ -1,0 +1,7 @@
+package com.processout.processout_sdk.ProcessOutExceptions;
+
+public class ProcessOutWebException extends ProcessOutException {
+    public ProcessOutWebException(String message) {
+        super(message);
+    }
+}

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ThreeDSHandler.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ThreeDSHandler.java
@@ -1,5 +1,7 @@
 package com.processout.processout_sdk;
 
+import com.processout.processout_sdk.POWebViews.ProcessOutWebView;
+
 public interface ThreeDSHandler {
 
     interface DoFingerprintCallback {
@@ -10,12 +12,15 @@ public interface ThreeDSHandler {
 
     interface DoChallengeCallback {
         void success();
+
         void error();
     }
 
     void doChallenge(AuthenticationChallengeData authentificationData, DoChallengeCallback callback);
 
-    void onSuccess(String invoiceId);
+    void doPresentWebView(ProcessOutWebView webView);
+
+    void onSuccess(String id);
 
     void onError(Exception error);
 }

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ThreeDSVerificationCallback.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ThreeDSVerificationCallback.java
@@ -2,5 +2,6 @@ package com.processout.processout_sdk;
 
 public interface ThreeDSVerificationCallback {
     public void onSuccess(String invoiceId);
+
     public void onError(Exception error);
 }

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/TokenRequest.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/TokenRequest.java
@@ -1,0 +1,16 @@
+package com.processout.processout_sdk;
+
+import com.google.gson.annotations.SerializedName;
+
+class TokenRequest {
+    @SerializedName("source")
+    private String source;
+    @SerializedName("verify")
+    private boolean verify = true;
+    @SerializedName("enable_three_d_s_2")
+    private boolean enableThreeDS2 = true;
+
+    TokenRequest(String source) {
+        this.source = source;
+    }
+}


### PR DESCRIPTION
# Migration

## New method
The `makeCardToken` is now available:
```java
p.makeCardToken("card-token", "customer-id", "token-id", ProcessOut.createDefaultTestHandler(MainActivity.this, new ProcessOut.ThreeDSHandlerTestCallback() {
    @Override
    public void onSuccess(String tokenId) {
        // The card has been verified
    }

    @Override
    public void onError(Exception error) {
        // Error
    }
}), with);
```

## ThreeDSHandler interface
The `ThreeDSHandler` interface has a new method:

```java
void doPresentWebView(ProcessOutWebView webView);
```

It is called when a web challenge is required. It is up to you to present the webview the way you want.

##  Deep-links handling
The only case where your app will be re-opened from a deep-link is when dealing with Alternative Payment Methods.

The `onCreate` method of your Activity should handle it like this:

```java
@Override
protected void onCreate(Bundle savedInstanceState) {
    super.onCreate(savedInstanceState);
    setContentView(R.layout.activity_main);

    Intent intent = getIntent();
    Uri data = intent.getData();
    if (data != null) {
        // Check if the activity has been opened from ProcessOut
        String gatewayToken = ProcessOut.handleURLCallback(data);
        if (gatewayToken != null)
            Log.d("PROCESSOUT", gatewayToken); // Send the token to backend to complete the charge
    }
}
```