### PR TITLE
Apm: add support for makeAPMToken method

### DIFF
--- a/processout-sdk/src/androidTest/java/com/processout/processout_sdk/ProcessOutTest.java
+++ b/processout-sdk/src/androidTest/java/com/processout/processout_sdk/ProcessOutTest.java
@@ -1,5 +1,7 @@
 package com.processout.processout_sdk;
 
+import android.net.Uri;
+
 import com.android.volley.Request;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -12,6 +14,9 @@ import java.util.concurrent.CountDownLatch;
 
 import androidx.test.core.app.ApplicationProvider;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 
@@ -77,5 +82,33 @@ public class ProcessOutTest {
             error.printStackTrace();
             fail("Could not run test");
         }
+    }
+
+    @Test
+    public void testReturnAPMTokenHandling() {
+        Uri testUri = Uri.parse("https://processout.return?token=test-token&customer_id=test-customer-id&token_id=test-token-id");
+        APMTokenReturn apmReturn = p.handleAMPURLCallback(testUri);
+        assertNotNull(apmReturn);
+        assertEquals(apmReturn.getType(), APMTokenReturn.APMReturnType.TokenCreation);
+        assertEquals(apmReturn.getCustomerId(), "test-customer-id");
+        assertEquals(apmReturn.getToken(), "test-token");
+        assertEquals(apmReturn.getTokenId(), "test-token-id");
+        assertEquals(apmReturn.getToken(), "test-token");
+    }
+
+    @Test
+    public void testReturnAPMPaymentHandling() {
+        Uri testUri = Uri.parse("https://processout.return?token=test-token");
+        APMTokenReturn apmReturn = p.handleAMPURLCallback(testUri);
+        assertNotNull(apmReturn);
+        assertEquals(apmReturn.getType(), APMTokenReturn.APMReturnType.Authorization);
+        assertEquals(apmReturn.getToken(), "test-token");
+    }
+
+    @Test
+    public void testReturnAPMWrongURI() {
+        Uri testUri = Uri.parse("https://processout.wrong?token=test-token&customer_id=test-customer-id&token_id=test-token-id");
+        APMTokenReturn apmReturn = p.handleAMPURLCallback(testUri);
+        assertNull(apmReturn);
     }
 }

--- a/processout-sdk/src/androidTest/java/com/processout/processout_sdk/ProcessOutTest.java
+++ b/processout-sdk/src/androidTest/java/com/processout/processout_sdk/ProcessOutTest.java
@@ -77,7 +77,7 @@ public class ProcessOutTest {
                         e.printStackTrace();
                         return;
                     }
-                    p.fetchGatewayConfigurations(invoiceResult.getId(), ProcessOut.GatewaysListingFilter.AlternativePaymentMethodWithTokenization, new FetchGatewaysConfigurationsCallback() {
+                    p.fetchGatewayConfigurations(ProcessOut.GatewaysListingFilter.AlternativePaymentMethodWithTokenization, new FetchGatewaysConfigurationsCallback() {
                         @Override
                         public void onSuccess(ArrayList<GatewayConfiguration> gateways) {
                             signal.countDown();

--- a/processout-sdk/src/androidTest/java/com/processout/processout_sdk/UITestSuite.java
+++ b/processout-sdk/src/androidTest/java/com/processout/processout_sdk/UITestSuite.java
@@ -16,6 +16,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 
 import androidx.test.filters.LargeTest;
@@ -67,7 +68,6 @@ public class UITestSuite {
                     fail("Could not encode body");
                     return;
                 }
-
                 Network.getTestInstance(withActivity, projectId, privateKey).CallProcessOut("/invoices", Request.Method.POST, body, new Network.NetworkResult() {
                     @Override
                     public void onError(Exception error) {
@@ -652,6 +652,31 @@ public class UITestSuite {
                         }, withActivity);
                     }
                 });
+            }
+        });
+
+        try {
+            signal.await();// wait for callback
+        } catch (InterruptedException e) {
+            fail("Could not run test");
+        }
+    }
+
+    @Test
+    public void testAPMTokenization() {
+        final CountDownLatch signal = new CountDownLatch(1);
+
+        final Activity withActivity = activityRule.getActivity();
+        final ProcessOut p = new ProcessOut(withActivity, "test-proj_gAO1Uu0ysZJvDuUpOGPkUBeE3pGalk3x");
+        p.listAlternativeMethods("iv_SuD6GUamoeLgYmRnDlEzM0wqamxW4WeY", new FetchGatewaysConfigurationsCallback() {
+            @Override
+            public void onSuccess(ArrayList<GatewayConfiguration> gateways) {
+                p.makeAPMToken(gateways.get(0), "cust_EiSdjbzbOPDMdFe0SFpe127T7eRcmLqK", "tok_ugUzL4AMG4ThOYOf2r12LKHFvlRyiEmV");
+            }
+
+            @Override
+            public void onError(Exception e) {
+                fail("Failed listing APM methods.");
             }
         });
 

--- a/processout-sdk/src/androidTest/java/com/processout/processout_sdk/UITestSuite.java
+++ b/processout-sdk/src/androidTest/java/com/processout/processout_sdk/UITestSuite.java
@@ -661,29 +661,4 @@ public class UITestSuite {
             fail("Could not run test");
         }
     }
-
-    @Test
-    public void testAPMTokenization() {
-        final CountDownLatch signal = new CountDownLatch(1);
-
-        final Activity withActivity = activityRule.getActivity();
-        final ProcessOut p = new ProcessOut(withActivity, "test-proj_gAO1Uu0ysZJvDuUpOGPkUBeE3pGalk3x");
-        p.listAlternativeMethods("iv_SuD6GUamoeLgYmRnDlEzM0wqamxW4WeY", new FetchGatewaysConfigurationsCallback() {
-            @Override
-            public void onSuccess(ArrayList<GatewayConfiguration> gateways) {
-                p.makeAPMToken(gateways.get(0), "cust_EiSdjbzbOPDMdFe0SFpe127T7eRcmLqK", "tok_ugUzL4AMG4ThOYOf2r12LKHFvlRyiEmV");
-            }
-
-            @Override
-            public void onError(Exception e) {
-                fail("Failed listing APM methods.");
-            }
-        });
-
-        try {
-            signal.await();// wait for callback
-        } catch (InterruptedException e) {
-            fail("Could not run test");
-        }
-    }
 }

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/APMTokenReturn.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/APMTokenReturn.java
@@ -1,0 +1,55 @@
+package com.processout.processout_sdk;
+
+import android.support.annotation.NonNull;
+
+import com.processout.processout_sdk.ProcessOutExceptions.ProcessOutException;
+
+public class APMTokenReturn {
+
+    public enum APMReturnType {
+        Authorization,
+        TokenCreation
+    }
+
+    private String token;
+    private String tokenId;
+    private String customerId;
+    private APMReturnType type;
+    private ProcessOutException error;
+
+    public APMTokenReturn(@NonNull String token, @NonNull String customerId, @NonNull String tokenId) {
+        this.token = token;
+        this.tokenId = tokenId;
+        this.customerId = customerId;
+        this.type = APMReturnType.TokenCreation;
+    }
+
+    public APMTokenReturn(@NonNull String token) {
+        this.token = token;
+        this.type = APMReturnType.Authorization;
+    }
+
+    public APMTokenReturn(ProcessOutException error) {
+        this.error = error;
+    }
+
+    public ProcessOutException getError() {
+        return error;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public String getTokenId() {
+        return tokenId;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public APMReturnType getType() {
+        return type;
+    }
+}

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/FetchGatewaysConfigurationsCallback.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/FetchGatewaysConfigurationsCallback.java
@@ -1,0 +1,9 @@
+package com.processout.processout_sdk;
+
+import java.util.ArrayList;
+
+public interface FetchGatewaysConfigurationsCallback {
+    void onSuccess(ArrayList<GatewayConfiguration> gateways);
+
+    void onError(Exception e);
+}

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/GatewayConfiguration.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/GatewayConfiguration.java
@@ -7,7 +7,7 @@ import android.support.annotation.NonNull;
 
 import com.google.gson.annotations.SerializedName;
 
-public class AlternativeGateway {
+public class GatewayConfiguration {
     @SerializedName("id")
     private String id;
     @SerializedName("name")

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/GatewayConfiguration.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/GatewayConfiguration.java
@@ -19,15 +19,6 @@ public class GatewayConfiguration {
     @SerializedName("gateway")
     private Gateway gateway;
 
-    private String invoiceId;
-    private String projectId;
-    private Context context;
-
-    public void redirect() {
-        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(Network.CHECKOUT_URL + "/" + this.projectId + "/" + this.invoiceId + "/redirect/" + this.id));
-        this.context.startActivity(browserIntent);
-    }
-
     public String getId() {
         return id;
     }
@@ -46,17 +37,5 @@ public class GatewayConfiguration {
 
     public Gateway getGateway() {
         return gateway;
-    }
-
-    public void setInvoiceId(String invoiceId) {
-        this.invoiceId = invoiceId;
-    }
-
-    public void setProjectId(String projectId) {
-        this.projectId = projectId;
-    }
-
-    public void setContext(Context context) {
-        this.context = context;
     }
 }

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ListAlternativeMethodsCallback.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ListAlternativeMethodsCallback.java
@@ -1,9 +1,0 @@
-package com.processout.processout_sdk;
-
-import java.util.ArrayList;
-
-public interface ListAlternativeMethodsCallback {
-    void onSuccess(ArrayList<AlternativeGateway> gateways);
-
-    void onError(Exception e);
-}

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
@@ -130,12 +130,13 @@ public class ProcessOut {
     }
 
     /**
-     * Retrieves the list of active alternative payment methods
+     * Retrieves the list of gateway configurations
      *
      * @param invoiceId Invoice ID that should be used for charging (this needs to be generated on your backend).
      *                  Keep in mind that you should set the return_url to "your_app://processout.return".
      *                  Check https://www.docs.processsout.com for more details
-     * @param callback  Callback for listing alternative payment methods
+     * @param filter    Filter for gateway configurations
+     * @param callback  Callback for listing gateway configurations
      */
     public void fetchGatewayConfigurations(@NonNull final String invoiceId, @NonNull GatewaysListingFilter filter, @NonNull final FetchGatewaysConfigurationsCallback callback) {
         final Context context = this.context;

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
@@ -132,16 +132,10 @@ public class ProcessOut {
     /**
      * Retrieves the list of gateway configurations
      *
-     * @param invoiceId Invoice ID that should be used for charging (this needs to be generated on your backend).
-     *                  Keep in mind that you should set the return_url to "your_app://processout.return".
-     *                  Check https://www.docs.processsout.com for more details
-     * @param filter    Filter for gateway configurations
-     * @param callback  Callback for listing gateway configurations
+     * @param filter   Filter for gateway configurations
+     * @param callback Callback for listing gateway configurations
      */
-    public void fetchGatewayConfigurations(@NonNull final String invoiceId, @NonNull GatewaysListingFilter filter, @NonNull final FetchGatewaysConfigurationsCallback callback) {
-        final Context context = this.context;
-        final String projectId = this.projectId;
-
+    public void fetchGatewayConfigurations(@NonNull GatewaysListingFilter filter, @NonNull final FetchGatewaysConfigurationsCallback callback) {
 
         String filterValue;
         switch (filter) {
@@ -172,9 +166,6 @@ public class ProcessOut {
                             for (int i = 0; i < configs.length(); i++) {
                                 GatewayConfiguration g = gson.fromJson(
                                         configs.getJSONObject(i).toString(), GatewayConfiguration.class);
-                                g.setContext(context);
-                                g.setProjectId(projectId);
-                                g.setInvoiceId(invoiceId);
                                 gways.add(g);
                             }
 
@@ -188,13 +179,26 @@ public class ProcessOut {
     }
 
     /**
-     * @param apm
-     * @param customerId
-     * @param tokenId
+     * Redirects the user to an alternative payment method payment page to authorize a token
+     *
+     * @param apm        Gateway previously retrieved
+     * @param customerId Customer ID created on your backend
+     * @param tokenId    Customer token ID created on your backend with empty source
      */
     public void makeAPMToken(@NonNull GatewayConfiguration apm, @NonNull String customerId, @NonNull String tokenId) {
         Intent browserIntent = new Intent(Intent.ACTION_VIEW,
                 Uri.parse(Network.CHECKOUT_URL + "/" + this.projectId + "/" + customerId + "/" + tokenId + "/redirect/" + apm.getId()));
+        this.context.startActivity(browserIntent);
+    }
+
+    /**
+     * Redirects the user to an alternative payment method payment page to complete a payment
+     *
+     * @param apm       Gateway previously retrieved
+     * @param invoiceId Invoice created on your backend
+     */
+    public void makeAPMPayment(@NonNull GatewayConfiguration apm, @NonNull String invoiceId) {
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(Network.CHECKOUT_URL + "/" + this.projectId + "/" + invoiceId + "/redirect/" + apm.getId()));
         this.context.startActivity(browserIntent);
     }
 

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
@@ -307,9 +307,10 @@ public class ProcessOut {
         String tokenId = uri.getQueryParameter("token_id");
 
         // if not check if we have a token
-        if (token == null || token.isEmpty())
+        if (token == null || token.isEmpty()) {
             // No parameter token is available
             return new APMTokenReturn(new ProcessOutException("Missing APM token in return paramaters"));
+        }
 
         // Check if we have a customer id and token id
         if (customerId != null && tokenId != null && !customerId.isEmpty() && !tokenId.isEmpty()) {

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
@@ -306,16 +306,17 @@ public class ProcessOut {
         String customerId = uri.getQueryParameter("customer_id");
         String tokenId = uri.getQueryParameter("token_id");
 
+        // if not check if we have a token
+        if (token == null || token.isEmpty())
+            // No parameter token is available
+            return new APMTokenReturn(new ProcessOutException("Missing APM token in return paramaters"));
+
         // Check if we have a customer id and token id
         if (customerId != null && tokenId != null && !customerId.isEmpty() && !tokenId.isEmpty()) {
             // Case of token creation
             return new APMTokenReturn(token, customerId, tokenId);
         }
 
-        // if not check if we have a token
-        if (token == null || token.isEmpty())
-            // No parameter token is available
-            return new APMTokenReturn(new ProcessOutException("Missing APM token in return paramaters"));
         // Case of simple APM authorization
         return new APMTokenReturn(token);
     }

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
@@ -307,17 +307,17 @@ public class ProcessOut {
         String tokenId = uri.getQueryParameter("token_id");
 
         // Check if we have a customer id and token id
-        if (customerId == null || tokenId == null || customerId.isEmpty() || tokenId.isEmpty()) {
-            // if not check if we have a token
-            if (token == null || token.isEmpty())
-                // No parameter token is available
-                return new APMTokenReturn(new ProcessOutException("Missing APM token in return paramaters"));
-            // Case of simple APM authorization
-            return new APMTokenReturn(token);
+        if (customerId != null && tokenId != null && !customerId.isEmpty() && !tokenId.isEmpty()) {
+            // Case of token creation
+            return new APMTokenReturn(token, customerId, tokenId);
         }
 
-        // Case of token creation
-        return new APMTokenReturn(token, customerId, tokenId);
+        // if not check if we have a token
+        if (token == null || token.isEmpty())
+            // No parameter token is available
+            return new APMTokenReturn(new ProcessOutException("Missing APM token in return paramaters"));
+        // Case of simple APM authorization
+        return new APMTokenReturn(token);
     }
 
     public interface ThreeDSHandlerTestCallback {

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 
 public class ProcessOut {
 
-    public static final String SDK_VERSION = "v2.10.0";
+    public static final String SDK_VERSION = "v2.11.0";
 
     private String projectId;
     private Context context;


### PR DESCRIPTION
# APM
It is now possible to create an APM token for customer token.

## Preparing a customer token
Refer to the [documentation to create a customer token](https://docs.processout.com/payments/save-token-and-capture-later/#step-2:-create-a-customer-token) **with an empty source**.

Also, during the token creation call, specify a `return_url` with your app scheme and `processout.return` as host.
Ex: `yourapp://processout.return`
This will allow your user to re-open the app once the APM verification is completed.

## Initiating an APM token creation

First list your available APM gateways:
```java
p.fetchGatewayConfigurations(ProcessOut.GatewaysListingFilter.AlternativePaymentMethodWithTokenization, new FetchGatewaysConfigurationsCallback() {
    @Override
    public void onSuccess(ArrayList<GatewayConfiguration> gateways) {
        p.makeAPMToken(gateways.get(0), "customer-id", "token-id");
    }

    @Override
    public void onError(Exception e) {
        Log.e("PROCESSOUT", e.toString());
    }
});
```

## Handling the user coming back to the app
Then in your `onCreate` function of the Activity handle user return like so:

```java
Intent intent = getIntent();
Uri data = intent.getData();
if (data == null) {
    this.initiatePayment();
    return;
}
ProcessOut p = new ProcessOut(this, "project-id");
APMTokenReturn apmReturn = p.handleAMPURLCallback(data);
if (apmReturn == null) {
    return;
}

switch (apmReturn.getType()) {
    case Authorization:
        // Call backend to charge with apmReturn.getToken()
        break;
    case TokenCreation:
        /* Call backend to update the customer token with:
            - customerId: apmReturn.getCustomerId()
            - tokenId: apmReturn.getTokenId()
            - source: apmReturn.getToken()
         */
        break;
}
```