### PR TITLE
Gateways: add public constructor to gateway objects

### DIFF
--- a/processout-sdk/src/main/java/com/processout/processout_sdk/Gateway.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/Gateway.java
@@ -14,6 +14,13 @@ public class Gateway {
     @SerializedName("tags")
     private ArrayList<String> tags;
 
+    public Gateway(String name, String displayName, String logoUrl, ArrayList<String> tags) {
+        this.name = name;
+        this.displayName = displayName;
+        this.logoUrl = logoUrl;
+        this.tags = tags;
+    }
+
     public String getName() {
         return name;
     }

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/GatewayConfiguration.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/GatewayConfiguration.java
@@ -19,6 +19,14 @@ public class GatewayConfiguration {
     @SerializedName("gateway")
     private Gateway gateway;
 
+    public GatewayConfiguration(String id, String name, boolean enabled, String defaultCurrency, Gateway gateway) {
+        this.id = id;
+        this.name = name;
+        this.enabled = enabled;
+        this.defaultCurrency = defaultCurrency;
+        this.gateway = gateway;
+    }
+
     public String getId() {
         return id;
     }


### PR DESCRIPTION
This allows merchants to reconstruct gateways list when re-opening the app without re-fetching them.