### PR TITLE
Implement incremental authorizations support

### DIFF
--- a/app/src/main/java/com/processout/processoutexample/MainActivity.java
+++ b/app/src/main/java/com/processout/processoutexample/MainActivity.java
@@ -46,7 +46,7 @@ public class MainActivity extends AppCompatActivity {
 
             @Override
             public void onSuccess(String token) {
-                p.makeCardPayment("invoiceId", token, ProcessOut.createDefaultTestHandler(MainActivity.this, new ProcessOut.ThreeDSHandlerTestCallback() {
+                p.makeCardPayment("invoiceId", token, false, ProcessOut.createDefaultTestHandler(MainActivity.this, new ProcessOut.ThreeDSHandlerTestCallback() {
                     @Override
                     public void onSuccess(String invoiceId) {
                         Log.d("PROCESSOUT", "invoice: " + invoiceId);

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/AuthorizationRequest.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/AuthorizationRequest.java
@@ -5,11 +5,14 @@ import com.google.gson.annotations.SerializedName;
 public class AuthorizationRequest {
     @SerializedName("source")
     private String source;
+    @SerializedName("incremental")
+    private boolean incremental;
     @SerializedName("enable_three_d_s_2")
     private boolean enableThreeDS2 = true;
 
-    public AuthorizationRequest(String source) {
+    public AuthorizationRequest(String source, boolean incremental) {
         this.source = source;
+        this.incremental = incremental;
     }
 
     public String getSource() {

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/IncrementAuthorizationRequest.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/IncrementAuthorizationRequest.java
@@ -1,0 +1,12 @@
+package com.processout.processout_sdk;
+
+import com.google.gson.annotations.SerializedName;
+
+public class IncrementAuthorizationRequest {
+    @SerializedName("amount")
+    private int amount;
+
+    public IncrementAuthorizationRequest(int amount) {
+        this.amount = amount;
+    }
+}


### PR DESCRIPTION
## Description
A new feature was recently implemented on the ProcessOut API that enables users to create authorizations where the value can be incremented at a later time. This PR makes it possible to utilize this feature from the ProcessOut Android SDK.

## Solution
This PR adds a new `incremental` parameter to the `makeCardPayment` function that will mark the resulting authorization as incremental. Once this has been done a newly implemented function, `incrementAuthorizationAmount`, can be used to increment the authorization by a provided amount. In addition, a unit test has been implemented to demonstrate this workflow.