### PR TITLE
Bump project version number to 2.14.0

### DIFF
--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 public class ProcessOut {
 
-    public static final String SDK_VERSION = "v2.12.0";
+    public static final String SDK_VERSION = "v2.14.0";
 
     private String projectId;
     private Context context;


### PR DESCRIPTION
The aim of this PR is to make the SDK report the correct version when making requests to the ProcessOut API.