### PR TITLE
Fix ClassCastException from Context to Activity in CustomerActionHandler.java

### DIFF
--- a/processout-sdk/src/main/java/com/processout/processout_sdk/CustomerActionHandler.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/CustomerActionHandler.java
@@ -86,8 +86,6 @@ class CustomerActionHandler {
                 processOutWebView.loadUrl(customerAction.getValue());
                 break;
             case FINGERPRINT:
-                FrameLayout rootLayout = ((Activity) (with)).findViewById(android.R.id.content);
-
                 // Building the possibly needed webView
                 final WebView FingerprintWebView = new WebView(this.with);
                 FingerprintWebView.getSettings().setUserAgentString("ProcessOut Android-Webview/" + ProcessOut.SDK_VERSION);
@@ -143,6 +141,7 @@ class CustomerActionHandler {
                 // Add the webview to content
                 if (with instanceof Activity) {
                     // We perform the fingerprint by displaying the hidden webview
+                    FrameLayout rootLayout = ((Activity) (with)).findViewById(android.R.id.content);
                     rootLayout.addView(FingerprintWebView);
                 } else {
                     // We can't instantiate the webview so fallback to default fingerprinting value


### PR DESCRIPTION
Fix possible `ClassCastException` in case if `with` parameter is not an instance of `Activtiy`.
Moved the casting right to the place where it's used and make it inside the "instanceof" check.