### PR TITLE
add message and SDK version support for 3ds2 auth

### DIFF
--- a/processout-sdk/src/main/java/com/processout/processout_sdk/AuthorizationRequest.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/AuthorizationRequest.java
@@ -9,6 +9,8 @@ public class AuthorizationRequest {
     private boolean incremental;
     @SerializedName("enable_three_d_s_2")
     private boolean enableThreeDS2 = true;
+    @SerializedName("sdk_version")
+    private String sdkVersion;
 
     public AuthorizationRequest(String source, boolean incremental) {
         this.source = source;
@@ -20,11 +22,21 @@ public class AuthorizationRequest {
         this.incremental = false;
     }
 
+    public AuthorizationRequest(String source, String sdkVersion) {
+        this.source = source;
+        this.incremental = false;
+        this.sdkVersion = sdkVersion;
+    }
+
     public String getSource() {
         return source;
     }
 
     public boolean isEnableThreeDS2() {
         return enableThreeDS2;
+    }
+
+    public String getSdkVersion() {
+        return sdkVersion;
     }
 }

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/AuthorizationRequest.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/AuthorizationRequest.java
@@ -9,8 +9,8 @@ public class AuthorizationRequest {
     private boolean incremental;
     @SerializedName("enable_three_d_s_2")
     private boolean enableThreeDS2 = true;
-    @SerializedName("sdk_version")
-    private String sdkVersion;
+    @SerializedName("third_party_sdk_version")
+    private String thirdPartySDKVersion;
 
     public AuthorizationRequest(String source, boolean incremental) {
         this.source = source;
@@ -22,10 +22,10 @@ public class AuthorizationRequest {
         this.incremental = false;
     }
 
-    public AuthorizationRequest(String source, String sdkVersion) {
+    public AuthorizationRequest(String source, String thirdPartySDKVersion) {
         this.source = source;
         this.incremental = false;
-        this.sdkVersion = sdkVersion;
+        this.thirdPartySDKVersion = thirdPartySDKVersion;
     }
 
     public String getSource() {
@@ -36,7 +36,7 @@ public class AuthorizationRequest {
         return enableThreeDS2;
     }
 
-    public String getSdkVersion() {
-        return sdkVersion;
+    public String getThirdPartySDKVersion() {
+        return thirdPartySDKVersion;
     }
 }

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/DirectoryServerData.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/DirectoryServerData.java
@@ -12,10 +12,15 @@ public class DirectoryServerData {
     @SerializedName("threeDSServerTransID")
     private String threeDSServerTransactionID;
 
-    public DirectoryServerData(String directoryServerID, String directoryServerPublicKey, String threeDSServerTransactionID) {
+    @SerializedName("messageVersion")
+    private String messageVersion;
+
+    public DirectoryServerData(String directoryServerID, String directoryServerPublicKey,
+                               String threeDSServerTransactionID, String messageVersion ) {
         this.directoryServerID = directoryServerID;
         this.directoryServerPublicKey = directoryServerPublicKey;
         this.threeDSServerTransactionID = threeDSServerTransactionID;
+        this.messageVersion = messageVersion;
     }
 
     public String getDirectoryServerID() {
@@ -28,5 +33,9 @@ public class DirectoryServerData {
 
     public String getThreeDSServerTransactionID() {
         return threeDSServerTransactionID;
+    }
+
+    public String getMessageVersion() {
+        return messageVersion;
     }
 }

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
@@ -257,13 +257,13 @@ public class ProcessOut {
      *
      * @param invoiceId previously generated invoice
      * @param source    source to use for the charge (card token, etc.)
-     * @param sdkVersion version of the 3rd party SDK being used for the calls.
+     * @param thirdPartySDKVersion version of the 3rd party SDK being used for the calls.
      * @param handler   (Custom 3DS2 handler)
      */
-    public void makeCardPayment(@NonNull final String invoiceId, @NonNull final String source, final String sdkVersion, @NonNull final ThreeDSHandler handler, @NonNull final Context with) {
+    public void makeCardPayment(@NonNull final String invoiceId, @NonNull final String source, final String thirdPartySDKVersion, @NonNull final ThreeDSHandler handler, @NonNull final Context with) {
         try {
             // Generate the authorization body and forces 3DS2
-            AuthorizationRequest authRequest = new AuthorizationRequest(source, sdkVersion);
+            AuthorizationRequest authRequest = new AuthorizationRequest(source, thirdPartySDKVersion);
             final JSONObject body = new JSONObject(gson.toJson(authRequest));
 
             requestAuthorization(invoiceId, body, new RequestAuthorizationCallback() {
@@ -288,7 +288,7 @@ public class ProcessOut {
                     CustomerActionHandler customerActionHandler = new CustomerActionHandler(handler, new PaymentWebView(with), with, new CustomerActionHandler.CustomerActionCallback() {
                         @Override
                         public void shouldContinue(String source) {
-                            makeCardPayment(invoiceId, source, sdkVersion, handler, with);
+                            makeCardPayment(invoiceId, source, thirdPartySDKVersion, handler, with);
                         }
                     });
                     customerActionHandler.handleCustomerAction(cA);


### PR DESCRIPTION
## Description
The scheme and the issuer can decide of the protocol of the version during an authentication to offer more features, like exemptions, delegated authentication (rely on a 3rd party to do the authentication) or decoupled authentication (authentication that isn’t in the 3DS flow, eg offline).

When doing an authentication, the payment provider will indicate us on what version should we authenticate.
As of now, we force our merchants to use a static value of 2.1.

## Solution
Overload makeCardPayment method to accept and forward the SDKVersion and also modify the DirectoryServerData class to be able to unmarshal the messageVersion and access it.

## Notes
Version of tessel9 needs to be update, don't mind the go-mod changes, used custom version of t9 to test this. 
This change requires a few other changes in these repos:
Tessel9 -> [PR-1827](https://github.com/processout/tessel9/pull/1827)
API  -> [PR-1743](https://github.com/processout/api/pull/1743)
iOS SDK -> [PR-36](https://github.com/processout/processout-ios/pull/36)

## Jira Issue
[PROCESS0UT-657](https://checkout.atlassian.net/jira/software/projects/PROCESS0UT/boards/530?selectedIssue=PROCESS0UT-657)