### PR TITLE
properly handle invalid response in network call

### DIFF
--- a/processout-sdk/src/main/java/com/processout/processout_sdk/Network.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/Network.java
@@ -77,11 +77,10 @@ class Network {
                             Gson g = new GsonBuilder()
                                     .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                                     .create();
-                            try
-                            {
+                            try {
                                ErrorReponse resp = g.fromJson(data, ErrorReponse.class);
                                callback.onError(new ProcessOutCardException(resp.getErrorMessage(), resp.getErrorType()));
-                            } catch (Exception e){
+                            } catch (Exception e) {
                                 callback.onError(new ProcessOutNetworkException("Received an unexpected response"));
                             }
                         } catch (UnsupportedEncodingException e) {

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/Network.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/Network.java
@@ -77,8 +77,13 @@ class Network {
                             Gson g = new GsonBuilder()
                                     .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                                     .create();
-                            ErrorReponse resp = g.fromJson(data, ErrorReponse.class);
-                            callback.onError(new ProcessOutCardException(resp.getErrorMessage(), resp.getErrorType()));
+                            try
+                            {
+                               ErrorReponse resp = g.fromJson(data, ErrorReponse.class);
+                               callback.onError(new ProcessOutCardException(resp.getErrorMessage(), resp.getErrorType()));
+                            } catch (Exception e){
+                                callback.onError(new ProcessOutNetworkException("Received an unexpected response"));
+                            }
                         } catch (UnsupportedEncodingException e) {
                             callback.onError(e);
                         }

--- a/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
+++ b/processout-sdk/src/main/java/com/processout/processout_sdk/ProcessOut.java
@@ -39,7 +39,7 @@ import java.util.Map;
 
 public class ProcessOut {
 
-    public static final String SDK_VERSION = "v2.18.1";
+    public static final String SDK_VERSION = "v2.18.2";
 
     private String projectId;
     private Context context;


### PR DESCRIPTION
We are trying to unmarshal an unexpected response in some cases and it's causing a crash since it's not properly handled. 

Related to: https://github.com/processout/processout-android/issues/36