### PR TITLE
feat(POM-256): Handle Custom Tab activity destruction

### DIFF
--- a/.github/workflows/create-release-and-publish.yml
+++ b/.github/workflows/create-release-and-publish.yml
@@ -14,7 +14,7 @@ jobs:
           RELEASE_VERSION=$(cat version.resolved)
           gh release create $RELEASE_VERSION --generate-notes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PO_GITHUB_TOKEN }}
 
       - name: Setup JDK 17
         uses: actions/setup-java@v3

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
     androidxConstraintLayoutVersion = '2.1.4'
     androidxActivityKtxVersion = '1.7.2'
     androidxFragmentKtxVersion = '1.6.1'
-    androidxLifecycleVersion = '2.5.1'
+    androidxLifecycleVersion = '2.6.1'
     androidxRecyclerViewVersion = '1.3.1'
     androidxBrowserVersion = '1.5.0'
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -104,6 +104,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintLayoutVersion"
     implementation "androidx.activity:activity-ktx:$androidxActivityKtxVersion"
     implementation "androidx.fragment:fragment-ktx:$androidxFragmentKtxVersion"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$androidxLifecycleVersion"
     implementation "androidx.browser:browser:$androidxBrowserVersion"
 
     implementation "com.google.android.material:material:$materialVersion"

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationUiState.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationUiState.kt
@@ -1,12 +1,25 @@
 package com.processout.sdk.ui.web.customtab
 
 import android.net.Uri
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
-internal sealed class CustomTabAuthorizationUiState {
+internal sealed class CustomTabAuthorizationUiState : Parcelable {
+    @Parcelize
     data object Initial : CustomTabAuthorizationUiState()
+
+    @Parcelize
     data class Launching(val uri: Uri) : CustomTabAuthorizationUiState()
+
+    @Parcelize
     data object Launched : CustomTabAuthorizationUiState()
+
+    @Parcelize
     data class Success(val returnUri: Uri) : CustomTabAuthorizationUiState()
+
+    @Parcelize
     data object Cancelled : CustomTabAuthorizationUiState()
+
+    @Parcelize
     data class Timeout(val clearBackStack: Boolean) : CustomTabAuthorizationUiState()
 }

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationViewModel.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationViewModel.kt
@@ -33,11 +33,14 @@ internal class CustomTabAuthorizationViewModel(
 
     companion object {
         private const val KEY_SAVED_STATE = "CustomTabAuthorizationUiState"
+        private const val CANCEL_DELAY_MS = 500L
     }
 
     val uiState = savedState.getStateFlow<CustomTabAuthorizationUiState>(KEY_SAVED_STATE, Initial)
 
     private val timeoutHandler by lazy { Handler(Looper.getMainLooper()) }
+
+    private val cancelRunnable = Runnable { savedState[KEY_SAVED_STATE] = Cancelled }
 
     init {
         configuration.timeoutSeconds?.let {
@@ -60,12 +63,22 @@ internal class CustomTabAuthorizationViewModel(
         }
         val returnUri = intent.data
         if (returnUri != null) {
+            timeoutHandler.removeCallbacks(cancelRunnable)
             POLogger.info("Custom Chrome Tabs has been redirected to return URL: %s", returnUri)
             savedState[KEY_SAVED_STATE] = Success(returnUri)
             return
         }
         when (uiState) {
-            is Launching, Launched -> savedState[KEY_SAVED_STATE] = Cancelled
+            is Launching, Launched ->
+                // Delay cancelling as return URI can be received shortly in the following scenario:
+                // 1) Activity and ViewModel has been destroyed while user is on the Custom Tab.
+                // 2) User has left Custom Tab immediately after passing the challenge (phone call, other app, home screen, etc...)
+                // and then goes back after redirect occurred. In this case the deep link will not be sent automatically and
+                // on some Chrome versions it will show a default dialog to confirm redirection to the app.
+                // 3) When user confirms redirect through this dialog first it will re-create Activity and ViewModel,
+                // which is in the Launched state. Normally it would trigger cancelling as user goes back from Custom Tab,
+                // but in this case we will also receive a deep link shortly after that.
+                timeoutHandler.postDelayed(cancelRunnable, CANCEL_DELAY_MS)
             else -> {}
         }
     }

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationViewModel.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationViewModel.kt
@@ -33,7 +33,7 @@ internal class CustomTabAuthorizationViewModel(
 
     companion object {
         private const val KEY_SAVED_STATE = "CustomTabAuthorizationUiState"
-        private const val CANCEL_DELAY_MS = 500L
+        private const val CANCEL_DELAY_MS = 700L
     }
 
     val uiState = savedState.getStateFlow<CustomTabAuthorizationUiState>(KEY_SAVED_STATE, Initial)

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabAuthorizationActivity.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabAuthorizationActivity.kt
@@ -42,12 +42,22 @@ class POCustomTabAuthorizationActivity : AppCompatActivity() {
             ActivityInfo.SCREEN_ORIENTATION_BEHIND else ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
 
         onBackPressedDispatcher.addCallback(this) {
-            // Consume back pressed to avoid finishing activity without result.
-            // Cancelled result will be provided from onResume() when going back from Custom Tab.
+            // Ignore back press to avoid finishing activity without a result.
+            // Cancelled result will be provided from onResume() when going back from the Custom Tab.
         }
 
         intent.getParcelableExtra<CustomTabConfiguration>(EXTRA_CONFIGURATION)
             ?.let { configuration = it }
+
+        if (::configuration.isInitialized.not()) {
+            finishWithActivityResult(
+                ProcessOutActivityResult.Failure(
+                    POFailure.Code.Internal(),
+                    "Configuration is not provided. Possibly started from redirect activity by a deep link when flow is already finished."
+                )
+            )
+            return
+        }
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabAuthorizationActivity.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabAuthorizationActivity.kt
@@ -28,7 +28,7 @@ class POCustomTabAuthorizationActivity : AppCompatActivity() {
     private lateinit var configuration: CustomTabConfiguration
 
     private val viewModel: CustomTabAuthorizationViewModel by viewModels {
-        CustomTabAuthorizationViewModel.Factory(configuration)
+        CustomTabAuthorizationViewModel.Factory(this, configuration)
     }
 
     @Suppress("DEPRECATION")
@@ -69,7 +69,7 @@ class POCustomTabAuthorizationActivity : AppCompatActivity() {
             Cancelled -> finishWithActivityResult(
                 ProcessOutActivityResult.Failure(
                     POFailure.Code.Cancelled,
-                    "Cancelled by user with back press or gesture."
+                    "Cancelled by user with back press, gesture or cancel button."
                 )
             )
             is Timeout -> handleTimeout(uiState.clearBackStack)

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabAuthorizationActivity.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabAuthorizationActivity.kt
@@ -6,6 +6,7 @@ import android.content.pm.ActivityInfo
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.browser.customtabs.CustomTabsIntent
@@ -39,6 +40,11 @@ class POCustomTabAuthorizationActivity : AppCompatActivity() {
         // https://stackoverflow.com/questions/48072438/java-lang-illegalstateexception-only-fullscreen-opaque-activities-can-request-o
         requestedOrientation = if (Build.VERSION.SDK_INT == Build.VERSION_CODES.O)
             ActivityInfo.SCREEN_ORIENTATION_BEHIND else ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+
+        onBackPressedDispatcher.addCallback(this) {
+            // Consume back pressed to avoid finishing activity without result.
+            // Cancelled result will be provided from onResume() when going back from Custom Tab.
+        }
 
         intent.getParcelableExtra<CustomTabConfiguration>(EXTRA_CONFIGURATION)
             ?.let { configuration = it }


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Fixed redirection loop when Activity and ViewModel is destroyed by saving ViewModel state in SavedStateHandle.
Fixed cancellation.
Handle case when deep link is received after flow is finished (consecutive redirection from Chrome browser instead of Custom Tab).

Tested with `Don't keep activities` developer option.

## Notes
<!--- Include any extra notes you may want the reviewer to know -->
Related issue: https://github.com/processout/processout-android/issues/111

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-256
