### PR TITLE
feat(POM-260): Prevent enums from being removed/obfuscated by R8/ProGuard

### DIFF
--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/request/POAllGatewayConfigurationsRequest.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/request/POAllGatewayConfigurationsRequest.kt
@@ -1,9 +1,12 @@
 package com.processout.sdk.api.model.request
 
+import com.squareup.moshi.JsonClass
+
 data class POAllGatewayConfigurationsRequest(
     val filter: Filter? = null,
     val withDisabled: Boolean = false
 ) {
+    @JsonClass(generateAdapter = false)
     enum class Filter(val queryValue: String) {
         CARD_PAYMENTS("card-payments"),
         ALTERNATIVE_PAYMENT_METHODS("alternative-payment-methods"),

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/request/POCardTokenizationRequest.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/request/POCardTokenizationRequest.kt
@@ -20,6 +20,7 @@ data class POCardTokenizationRequest(
     val tokenType: TokenType? = null,
     val paymentToken: String? = ""
 ) {
+    @JsonClass(generateAdapter = false)
     enum class TokenType(val value: String) {
         GOOGLE_PAY("googlepay")
     }

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/response/POAlternativePaymentMethodResponse.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/response/POAlternativePaymentMethodResponse.kt
@@ -1,5 +1,7 @@
 package com.processout.sdk.api.model.response
 
+import com.squareup.moshi.JsonClass
+
 /**
  * Response of the alternative payment.
  *
@@ -14,6 +16,7 @@ data class POAlternativePaymentMethodResponse(
     val tokenId: String?,
     val returnType: APMReturnType
 ) {
+    @JsonClass(generateAdapter = false)
     enum class APMReturnType {
         AUTHORIZATION,
         CREATE_TOKEN

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/response/POCustomerAction.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/response/POCustomerAction.kt
@@ -12,6 +12,7 @@ internal data class POCustomerAction(
 ) {
     fun type() = Type::rawType.findBy(rawType) ?: Type.UNSUPPORTED
 
+    @JsonClass(generateAdapter = false)
     enum class Type(val rawType: String) {
         FINGERPRINT_MOBILE("fingerprint-mobile"),
         CHALLENGE_MOBILE("challenge-mobile"),

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/response/POCustomerTokenResponse.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/response/POCustomerTokenResponse.kt
@@ -67,6 +67,7 @@ data class POCustomerToken(
     /**
      * Customer token verification status.
      */
+    @JsonClass(generateAdapter = false)
     enum class VerificationStatus(value: String) {
         SUCCESS("success"),
         PENDING("pending"),

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/response/PONativeAlternativePaymentMethodParameter.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/response/PONativeAlternativePaymentMethodParameter.kt
@@ -19,6 +19,7 @@ data class PONativeAlternativePaymentMethodParameter(
 
     fun type() = ParameterType::rawType.findBy(rawType) ?: ParameterType.UNKNOWN
 
+    @JsonClass(generateAdapter = false)
     enum class ParameterType(val rawType: String) {
         NUMERIC("numeric"),
         TEXT("text"),

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/response/PONativeAlternativePaymentMethodState.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/response/PONativeAlternativePaymentMethodState.kt
@@ -1,5 +1,8 @@
 package com.processout.sdk.api.model.response
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = false)
 enum class PONativeAlternativePaymentMethodState {
     CUSTOMER_INPUT,
     PENDING_CAPTURE,

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/threeds/PO3DS2Configuration.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/threeds/PO3DS2Configuration.kt
@@ -31,6 +31,7 @@ data class PO3DS2Configuration(
     /**
      * Supported card schemes.
      */
+    @JsonClass(generateAdapter = false)
     enum class CardScheme(val rawType: String) {
         VISA("visa"),
         MASTERCARD("mastercard"),


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Annotated all request/response enums with `@JsonClass(generateAdapter = false)` to prevent them from being removed/obfuscated by R8/ProGuard.
It's required by Moshi when obfuscation is enabled:
https://github.com/square/moshi#enums

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-260
