### PR TITLE
fix(POM-268): Native APM binding NPE in animation callback

### DIFF
--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodBottomSheet.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodBottomSheet.kt
@@ -541,6 +541,7 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment(),
                     .setDuration(ANIMATION_DURATION_MS)
                     .setListener(object : AnimatorListenerAdapter() {
                         override fun onAnimationEnd(animation: Animator) {
+                            if (_binding == null) return
                             bindCapture(uiModel)
                             adjustPeekHeight(animate = true)
                             fadeIn(listOf(this@with), ANIMATION_DURATION_MS)
@@ -671,6 +672,7 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment(),
                 .setDuration(ANIMATION_DURATION_MS)
                 .setListener(object : AnimatorListenerAdapter() {
                     override fun onAnimationEnd(animation: Animator) {
+                        if (_binding == null) return
                         bindSuccess(uiModel)
                         adjustPeekHeight(animate = true)
                         fadeIn(
@@ -761,18 +763,24 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment(),
 
     override fun onPause() {
         super.onPause()
-        clearAnimationListeners()
+        cancelAnimations()
         handler.removeCallbacksAndMessages(null)
         bottomSheetBehavior.removeBottomSheetCallback(bottomSheetBehaviorCallback)
         finishWithSuccess()
     }
 
-    private fun clearAnimationListeners() {
+    private fun cancelAnimations() {
         if (_binding != null) {
-            binding.poContainer.animate().setListener(null)
+            with(binding.poContainer.animate()) {
+                setListener(null)
+                cancel()
+            }
         }
         if (_bindingCapture != null) {
-            bindingCapture.poBackground.animate().setListener(null)
+            with(bindingCapture.poBackground.animate()) {
+                setListener(null)
+                cancel()
+            }
         }
     }
 
@@ -840,7 +848,7 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment(),
 
     private fun finish() {
         if (isAdded) {
-            dismiss()
+            dismissAllowingStateLoss()
             activityCallback.onBottomSheetFinished()
         }
     }


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Properly canceles animations when user leaves the screen during animation.
This prevents binding NPE crash and allows to restore the state correctly when user goes back to the screen.

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-268
