### PR TITLE
fix(ad-hoc): Lighter drag handle color on native APM

### DIFF
--- a/sdk/src/main/res/drawable/po_drag_handle.xml
+++ b/sdk/src/main/res/drawable/po_drag_handle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/po_border_default" />
+    <solid android:color="@color/po_action_border_disabled" />
     <size
         android:width="@dimen/po_dragHandle_width"
         android:height="@dimen/po_dragHandle_height" />


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Lighter drag handle color on native APM bottom sheet to match with Card Update.

<img src=https://github.com/processout/processout-android/assets/114916876/e27ee696-a4a0-47ef-af82-a7523e5ff413, width=300/>
<img src=https://github.com/processout/processout-android/assets/114916876/eea735cb-4100-4100-bc8c-fca405bcdf79, width=300/>