### PR TITLE
feat(POM-327): Token is optional when parsing 3DS and APM return deep link

### DIFF
--- a/sdk/src/main/kotlin/com/processout/sdk/api/service/DefaultAlternativePaymentMethodsService.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/service/DefaultAlternativePaymentMethodsService.kt
@@ -35,16 +35,18 @@ internal class DefaultAlternativePaymentMethodsService(
     }
 
     override fun alternativePaymentMethodResponse(uri: Uri): ProcessOutResult<POAlternativePaymentMethodResponse> {
-        val errorMessage = "Invalid or malformed Alternative Payment Method URL: $uri"
-        if (uri.isOpaque)
-            return ProcessOutResult.Failure(code = Internal(), message = errorMessage)
+        if (uri.isOpaque) {
+            return ProcessOutResult.Failure(
+                code = Internal(),
+                message = "Invalid or malformed alternative payment method URI: $uri"
+            )
+        }
 
         uri.getQueryParameter("error_code")?.let { errorCode ->
             return ProcessOutResult.Failure(failureCode(errorCode))
         }
 
-        val gatewayToken = uri.getQueryParameter("token")
-            ?: return ProcessOutResult.Failure(code = Internal(), message = errorMessage)
+        val gatewayToken = uri.getQueryParameter("token") ?: String()
 
         val customerId = uri.getQueryParameter("customer_id")
         val tokenId = uri.getQueryParameter("token_id")

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/apm/POAlternativePaymentMethodCustomTabLauncher.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/apm/POAlternativePaymentMethodCustomTabLauncher.kt
@@ -151,6 +151,7 @@ class POAlternativePaymentMethodCustomTabLauncher private constructor(
             customTabLauncher.launch(
                 CustomTabConfiguration(
                     uri = uri,
+                    returnUri = Uri.parse(returnUrl),
                     timeoutSeconds = null
                 )
             )

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/threeds/PO3DSRedirectCustomTabLauncher.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/threeds/PO3DSRedirectCustomTabLauncher.kt
@@ -95,6 +95,7 @@ class PO3DSRedirectCustomTabLauncher private constructor(
             customTabLauncher.launch(
                 CustomTabConfiguration(
                     uri = delegate.uri,
+                    returnUri = Uri.parse(returnUrl),
                     timeoutSeconds = redirect.timeoutSeconds
                 )
             )

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/threeds/ThreeDSRedirectWebAuthorizationDelegate.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/threeds/ThreeDSRedirectWebAuthorizationDelegate.kt
@@ -15,14 +15,20 @@ internal class ThreeDSRedirectWebAuthorizationDelegate(
     }
 
     override fun complete(uri: Uri) {
-        uri.getQueryParameter(TOKEN_QUERY_KEY)?.let { token ->
-            callback(ProcessOutResult.Success(token))
-        } ?: callback(
-            ProcessOutResult.Failure(
-                POFailure.Code.Internal(),
-                "Token not found in URI: $uri"
+        if (uri.isHierarchical) {
+            callback(
+                ProcessOutResult.Success(
+                    value = uri.getQueryParameter(TOKEN_QUERY_KEY) ?: String()
+                )
             )
-        )
+        } else {
+            callback(
+                ProcessOutResult.Failure(
+                    code = POFailure.Code.Internal(),
+                    message = "Invalid or malformed 3DS redirect URI: $uri"
+                )
+            )
+        }
     }
 
     override fun complete(failure: ProcessOutResult.Failure) {

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationUiState.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationUiState.kt
@@ -2,6 +2,7 @@ package com.processout.sdk.ui.web.customtab
 
 import android.net.Uri
 import android.os.Parcelable
+import com.processout.sdk.core.ProcessOutActivityResult
 import kotlinx.parcelize.Parcelize
 
 internal sealed class CustomTabAuthorizationUiState : Parcelable {
@@ -16,6 +17,9 @@ internal sealed class CustomTabAuthorizationUiState : Parcelable {
 
     @Parcelize
     data class Success(val returnUri: Uri) : CustomTabAuthorizationUiState()
+
+    @Parcelize
+    data class Failure(val failure: ProcessOutActivityResult.Failure) : CustomTabAuthorizationUiState()
 
     @Parcelize
     data object Cancelled : CustomTabAuthorizationUiState()

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationViewModel.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.savedstate.SavedStateRegistryOwner
+import com.processout.sdk.core.POFailure
+import com.processout.sdk.core.ProcessOutActivityResult
 import com.processout.sdk.core.logger.POLogger
 import com.processout.sdk.ui.web.customtab.CustomTabAuthorizationActivityContract.Companion.EXTRA_TIMEOUT_FINISH
 import com.processout.sdk.ui.web.customtab.CustomTabAuthorizationUiState.*
@@ -59,8 +61,19 @@ internal class CustomTabAuthorizationViewModel(
         val returnUri = intent.data
         if (returnUri != null) {
             timeoutHandler.removeCallbacks(cancellationRunnable)
-            POLogger.info("Custom Chrome Tabs has been redirected to return URL: %s", returnUri)
-            savedState[KEY_SAVED_STATE] = Success(returnUri)
+            if (returnUri.toString().startsWith(configuration.returnUri.toString())) {
+                POLogger.info("Custom Chrome Tabs has been redirected to return URI: %s", returnUri)
+                savedState[KEY_SAVED_STATE] = Success(returnUri)
+            } else {
+                val errorMessage = "Unexpected Custom Chrome Tabs redirect to URI: $returnUri"
+                POLogger.error(errorMessage)
+                savedState[KEY_SAVED_STATE] = Failure(
+                    ProcessOutActivityResult.Failure(
+                        code = POFailure.Code.Internal(),
+                        message = errorMessage
+                    )
+                )
+            }
             return
         }
         when (uiState) {

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationViewModel.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationViewModel.kt
@@ -61,7 +61,10 @@ internal class CustomTabAuthorizationViewModel(
         val returnUri = intent.data
         if (returnUri != null) {
             timeoutHandler.removeCallbacks(cancellationRunnable)
-            if (returnUri.toString().startsWith(configuration.returnUri.toString())) {
+            if (returnUri.scheme == configuration.returnUri.scheme &&
+                returnUri.host == configuration.returnUri.host &&
+                returnUri.path == configuration.returnUri.path
+            ) {
                 POLogger.info("Custom Chrome Tabs has been redirected to return URI: %s", returnUri)
                 savedState[KEY_SAVED_STATE] = Success(returnUri)
             } else {

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabConfiguration.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabConfiguration.kt
@@ -7,5 +7,6 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 internal data class CustomTabConfiguration(
     val uri: Uri,
+    val returnUri: Uri,
     val timeoutSeconds: Int? = null
 ) : Parcelable

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabAuthorizationActivity.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabAuthorizationActivity.kt
@@ -87,6 +87,7 @@ class POCustomTabAuthorizationActivity : AppCompatActivity() {
             is Success -> finishWithActivityResult(
                 ProcessOutActivityResult.Success(uiState.returnUri)
             )
+            is Failure -> finishWithActivityResult(uiState.failure)
             Cancelled -> finishWithActivityResult(
                 ProcessOutActivityResult.Failure(
                     POFailure.Code.Cancelled,

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/webview/ProcessOutWebView.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/webview/ProcessOutWebView.kt
@@ -136,7 +136,7 @@ internal class ProcessOutWebView(
             }
         } ?: complete(
             ProcessOutResult.Failure(
-                POFailure.Code.Internal(),
+                POFailure.Code.Generic(),
                 "$description | Failed to load URL: $failingUrl"
             )
         )

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/webview/ProcessOutWebView.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/webview/ProcessOutWebView.kt
@@ -66,10 +66,9 @@ internal class ProcessOutWebView(
                     val uri = Uri.parse(it)
                     if (uri.isHierarchical) {
                         configuration.returnUris.find { returnUri ->
-                            val returnUrl = returnUri.toString()
-                            if (returnUrl.isNotBlank()) {
-                                uri.toString().startsWith(returnUrl)
-                            } else false
+                            uri.scheme == returnUri.scheme &&
+                                    uri.host == returnUri.host &&
+                                    uri.path == returnUri.path
                         }?.let { complete(uri) }
                     }
                 }

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/webview/ProcessOutWebView.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/webview/ProcessOutWebView.kt
@@ -64,11 +64,11 @@ internal class ProcessOutWebView(
                 super.onPageStarted(view, url, favicon)
                 url?.let {
                     val uri = Uri.parse(it)
-                    if (uri.isHierarchical && uri.path != null) {
+                    if (uri.isHierarchical) {
                         configuration.returnUris.find { returnUri ->
                             val returnUrl = returnUri.toString()
                             if (returnUrl.isNotBlank()) {
-                                uri.toString().startsWith(returnUrl, ignoreCase = false)
+                                uri.toString().startsWith(returnUrl)
                             } else false
                         }?.let { complete(uri) }
                     }

--- a/sdk/src/test/kotlin/com/processout/sdk/AlternativePaymentMethodsServiceTests.kt
+++ b/sdk/src/test/kotlin/com/processout/sdk/AlternativePaymentMethodsServiceTests.kt
@@ -85,6 +85,19 @@ class AlternativePaymentMethodsServiceTests {
     }
 
     @Test
+    fun alternativePaymentMethodResponseWithoutGatewayToken() {
+        val returnUrl = "https://processout.return"
+
+        apmService.alternativePaymentMethodResponse(Uri.parse(returnUrl)).let { result ->
+            result.assertFailure()
+            result.onSuccess { response ->
+                assert(response.gatewayToken.isEmpty())
+                assert(response.returnType == POAlternativePaymentMethodResponse.APMReturnType.AUTHORIZATION)
+            }
+        }
+    }
+
+    @Test
     fun alternativePaymentMethodResponseWithCustomerToken() {
         val returnUrl = "https://processout.return?token=gway_req_test" +
                 "&token_id=tok_test&customer_id=cust_test"

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
@@ -2,12 +2,15 @@ package com.processout.sdk.ui.card.tokenization
 
 import android.os.Parcelable
 import androidx.annotation.ColorRes
+import com.processout.sdk.core.annotation.ProcessOutInternalApi
 import com.processout.sdk.ui.core.style.POActionsContainerStyle
 import com.processout.sdk.ui.core.style.POFieldStyle
 import com.processout.sdk.ui.core.style.POTextStyle
 import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
 import kotlinx.parcelize.Parcelize
 
+/** @suppress */
+@ProcessOutInternalApi
 @Parcelize
 data class POCardTokenizationConfiguration(
     val title: String? = null,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationFormData.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationFormData.kt
@@ -1,8 +1,11 @@
 package com.processout.sdk.ui.card.tokenization
 
 import android.os.Parcelable
+import com.processout.sdk.core.annotation.ProcessOutInternalApi
 import kotlinx.parcelize.Parcelize
 
+/** @suppress */
+@ProcessOutInternalApi
 @Parcelize
 data class POCardTokenizationFormData(
     internal val cardInformation: CardInformation,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationLauncher.kt
@@ -4,10 +4,13 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.Fragment
 import com.processout.sdk.core.ProcessOutActivityResult
+import com.processout.sdk.core.annotation.ProcessOutInternalApi
 
 /**
  * Launcher that starts [CardTokenizationActivity] and provides the result.
  */
+/** @suppress */
+@ProcessOutInternalApi
 class POCardTokenizationLauncher private constructor() {
 
     private lateinit var launcher: ActivityResultLauncher<POCardTokenizationConfiguration>

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationResponse.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationResponse.kt
@@ -2,8 +2,11 @@ package com.processout.sdk.ui.card.tokenization
 
 import android.os.Parcelable
 import com.processout.sdk.api.model.response.POCard
+import com.processout.sdk.core.annotation.ProcessOutInternalApi
 import kotlinx.parcelize.Parcelize
 
+/** @suppress */
+@ProcessOutInternalApi
 @Parcelize
 data class POCardTokenizationResponse(
     val card: POCard,


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
1) `token` query parameter in deep link return URI is now optional for 3DS and web APM flows.
2) Custom Chrome Tab return URI is validated against value that was provided to launcher.
3) Small improvements in ProcessOutWebView.

## Note
Public card tokenization classes marked as internal because they are WIP.

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-327
