### PR TITLE
fix(POM-331): Crash while parsing result in activity contract

### DIFF
--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodActivityContract.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodActivityContract.kt
@@ -25,10 +25,12 @@ class PONativeAlternativePaymentMethodActivityContract : ActivityResultContract
     override fun parseResult(
         resultCode: Int,
         intent: Intent?
-    ): PONativeAlternativePaymentMethodResult =
-        intent?.getParcelableExtra(EXTRA_RESULT)
+    ): PONativeAlternativePaymentMethodResult {
+        intent?.setExtrasClassLoader(PONativeAlternativePaymentMethodResult::class.java.classLoader)
+        return intent?.getParcelableExtra(EXTRA_RESULT)
             ?: PONativeAlternativePaymentMethodResult.Failure(
-                POFailure.Code.Internal(),
-                "Activity result was not provided."
+                code = POFailure.Code.Internal(),
+                message = "Activity result was not provided."
             ).also { POLogger.error("%s", it) }
+    }
 }

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationActivityContract.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationActivityContract.kt
@@ -28,10 +28,12 @@ internal class CustomTabAuthorizationActivityContract : ActivityResultContract
     override fun parseResult(
         resultCode: Int,
         intent: Intent?
-    ): ProcessOutActivityResult<Uri> =
-        intent?.getParcelableExtra(EXTRA_RESULT)
+    ): ProcessOutActivityResult<Uri> {
+        intent?.setExtrasClassLoader(ProcessOutActivityResult::class.java.classLoader)
+        return intent?.getParcelableExtra(EXTRA_RESULT)
             ?: ProcessOutActivityResult.Failure(
-                POFailure.Code.Internal(),
-                "Activity result was not provided."
+                code = POFailure.Code.Internal(),
+                message = "Activity result was not provided."
             ).also { POLogger.error("%s", it) }
+    }
 }

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/webview/WebViewAuthorizationActivityContract.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/webview/WebViewAuthorizationActivityContract.kt
@@ -27,10 +27,12 @@ internal class WebViewAuthorizationActivityContract : ActivityResultContract
     override fun parseResult(
         resultCode: Int,
         intent: Intent?
-    ): ProcessOutActivityResult<Uri> =
-        intent?.getParcelableExtra(EXTRA_RESULT)
+    ): ProcessOutActivityResult<Uri> {
+        intent?.setExtrasClassLoader(ProcessOutActivityResult::class.java.classLoader)
+        return intent?.getParcelableExtra(EXTRA_RESULT)
             ?: ProcessOutActivityResult.Failure(
-                POFailure.Code.Internal(),
-                "Activity result was not provided."
+                code = POFailure.Code.Internal(),
+                message = "Activity result was not provided."
             ).also { POLogger.error("%s", it) }
+    }
 }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationActivityContract.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationActivityContract.kt
@@ -26,10 +26,12 @@ internal class CardTokenizationActivityContract : ActivityResultContract
     override fun parseResult(
         resultCode: Int,
         intent: Intent?
-    ): ProcessOutActivityResult<POCardTokenizationResponse> =
-        intent?.getParcelableExtra(EXTRA_RESULT)
+    ): ProcessOutActivityResult<POCardTokenizationResponse> {
+        intent?.setExtrasClassLoader(ProcessOutActivityResult::class.java.classLoader)
+        return intent?.getParcelableExtra(EXTRA_RESULT)
             ?: ProcessOutActivityResult.Failure(
                 code = POFailure.Code.Internal(),
                 message = "Activity result was not provided."
             ).also { POLogger.error("%s", it) }
+    }
 }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateActivityContract.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateActivityContract.kt
@@ -27,10 +27,12 @@ internal class CardUpdateActivityContract : ActivityResultContract
     override fun parseResult(
         resultCode: Int,
         intent: Intent?
-    ): ProcessOutActivityResult<POCard> =
-        intent?.getParcelableExtra(EXTRA_RESULT)
+    ): ProcessOutActivityResult<POCard> {
+        intent?.setExtrasClassLoader(ProcessOutActivityResult::class.java.classLoader)
+        return intent?.getParcelableExtra(EXTRA_RESULT)
             ?: ProcessOutActivityResult.Failure(
                 code = POFailure.Code.Internal(),
                 message = "Activity result was not provided."
             ).also { POLogger.error("%s", it) }
+    }
 }


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
In low memory condition Android can persist activity result and parse it in its own process using framework class loader, which cannot load classes from SDK.
```
Fatal Exception: android.os.BadParcelableException: ClassNotFoundException when unmarshalling: com.processout.sdk.core.ProcessOutActivityResult$Success
```

## Solution
<!--- Describe the solution/fix implemented in this PR. -->
`setExtrasClassLoader()` when parsing result in all activity contracts.

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-331
