### PR TITLE
feat(POM-351): (Native APM) Optional loader by timeout on capture screen

### DIFF
--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodUiState.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodUiState.kt
@@ -45,6 +45,7 @@ internal data class NativeAlternativePaymentMethodUiModel(
     val primaryActionText: String,
     val secondaryAction: SecondaryActionUiModel?,
     val paymentConfirmationSecondaryAction: SecondaryActionUiModel?,
+    val isPaymentConfirmationProgressIndicatorVisible: Boolean,
     val isSubmitting: Boolean
 ) {
     fun isSubmitAllowed() = inputParameters.all { it.state is Input.State.Default }

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
@@ -398,6 +398,11 @@ internal class NativeAlternativePaymentMethodViewModel(
             animateViewTransition = true
             _uiState.value = Capture(updatedUiModel)
 
+            options.showPaymentConfirmationProgressIndicatorAfterSeconds?.let { afterSeconds ->
+                showPaymentConfirmationProgressIndicator(
+                    afterMillis = TimeUnit.SECONDS.toMillis(afterSeconds.toLong())
+                )
+            }
             updatedUiModel.paymentConfirmationSecondaryAction?.let {
                 scheduleSecondaryActionEnabling(it) { enablePaymentConfirmationSecondaryAction() }
             }
@@ -590,6 +595,7 @@ internal class NativeAlternativePaymentMethodViewModel(
             primaryActionText = options.primaryActionText ?: invoice.formatPrimaryActionText(),
             secondaryAction = options.secondaryAction?.toUiModel(),
             paymentConfirmationSecondaryAction = options.paymentConfirmationSecondaryAction?.toUiModel(),
+            isPaymentConfirmationProgressIndicatorVisible = false,
             isSubmitting = false
         )
 
@@ -695,6 +701,16 @@ internal class NativeAlternativePaymentMethodViewModel(
                     )
                 )
             )
+        }
+    }
+
+    private fun showPaymentConfirmationProgressIndicator(afterMillis: Long) {
+        handler.postDelayed(delayInMillis = afterMillis) {
+            _uiState.value.doWhenCapture { uiModel ->
+                _uiState.value = Capture(
+                    uiModel.copy(isPaymentConfirmationProgressIndicatorVisible = true)
+                )
+            }
         }
     }
 

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodBottomSheet.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodBottomSheet.kt
@@ -554,6 +554,11 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment(),
         bindPaymentConfirmationSecondaryButton(uiModel)
         if (uiModel.showCustomerAction()) {
             bindingCapture.poCircularProgressIndicator.visibility = View.GONE
+            if (uiModel.isPaymentConfirmationProgressIndicatorVisible) {
+                bindingCapture.poCaptureCircularProgressIndicator.visibility = View.VISIBLE
+            } else {
+                bindingCapture.poCaptureCircularProgressIndicator.visibility = View.GONE
+            }
             bindCaptureHeader(
                 uiModel,
                 titleStyle = POTextStyle(
@@ -567,6 +572,7 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment(),
             uiModel.customerActionMessageMarkdown?.let { bindCustomerActionMessage(it) }
         } else {
             bindingCapture.poCircularProgressIndicator.visibility = View.VISIBLE
+            bindingCapture.poCaptureCircularProgressIndicator.visibility = View.GONE
             bindingCapture.poMessage.visibility = View.GONE
             bindingCapture.poHeader.visibility = View.GONE
             bindingCapture.poActionImage.visibility = View.GONE
@@ -656,6 +662,7 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment(),
             fadeOut(
                 listOf(
                     bindingCapture.poCircularProgressIndicator,
+                    bindingCapture.poCaptureCircularProgressIndicator,
                     bindingCapture.poMessage,
                     bindingCapture.poActionImage,
                     bindingCapture.poFooter
@@ -692,6 +699,7 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment(),
 
     private fun bindSuccess(uiModel: NativeAlternativePaymentMethodUiModel) {
         bindingCapture.poCircularProgressIndicator.visibility = View.GONE
+        bindingCapture.poCaptureCircularProgressIndicator.visibility = View.GONE
         bindSuccessBackground()
         bindSuccessMessage(uiModel.successMessage)
         bindCaptureHeader(

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodConfiguration.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodConfiguration.kt
@@ -46,6 +46,8 @@ data class PONativeAlternativePaymentMethodConfiguration(
      * Maximum value is 180 seconds, this is a default.
      * @param[paymentConfirmationSecondaryAction] Action that could be optionally presented to user during payment confirmation stage.
      * To hide action use _null_, this is a default behaviour.
+     * @param[showPaymentConfirmationProgressIndicatorAfterSeconds] Show progress indicator during payment confirmation after provided delay (in seconds).
+     * To hide progress indicator use _null_, this is a default behaviour.
      */
     @Parcelize
     data class Options(
@@ -58,7 +60,8 @@ data class PONativeAlternativePaymentMethodConfiguration(
         val skipSuccessScreen: Boolean = false,
         val waitsPaymentConfirmation: Boolean = true,
         val paymentConfirmationTimeoutSeconds: Int = MAX_PAYMENT_CONFIRMATION_TIMEOUT_SECONDS,
-        val paymentConfirmationSecondaryAction: SecondaryAction? = null
+        val paymentConfirmationSecondaryAction: SecondaryAction? = null,
+        val showPaymentConfirmationProgressIndicatorAfterSeconds: Int? = null
     ) : Parcelable {
         companion object {
             const val MAX_PAYMENT_CONFIRMATION_TIMEOUT_SECONDS = 180

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/StyleCustomization.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/StyleCustomization.kt
@@ -45,7 +45,10 @@ internal fun PoBottomSheetNativeApmBinding.applyStyle(
 internal fun PoBottomSheetCaptureBinding.applyStyle(
     style: PONativeAlternativePaymentMethodConfiguration.Style
 ) {
-    style.progressIndicatorColor?.let { poCircularProgressIndicator.setIndicatorColor(it) }
+    style.progressIndicatorColor?.let {
+        poCircularProgressIndicator.setIndicatorColor(it)
+        poCaptureCircularProgressIndicator.setIndicatorColor(it)
+    }
     style.successImageResId?.let { poSuccessImage.setImageResource(it) }
     style.message?.let { poMessage.applyStyle(it) }
     style.secondaryButton?.let { poSecondaryButton.applyStyle(it) }

--- a/sdk/src/main/res/layout/po_bottom_sheet_capture.xml
+++ b/sdk/src/main/res/layout/po_bottom_sheet_capture.xml
@@ -83,6 +83,18 @@
                     tools:text="Provider Title" />
             </FrameLayout>
 
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/po_capture_circular_progress_indicator"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/po_capture_content_margin"
+                android:indeterminate="true"
+                android:visibility="gone"
+                app:layout_constraintBottom_toTopOf="@id/po_message"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/po_header" />
+
             <TextView
                 android:id="@+id/po_message"
                 style="@style/Widget.ProcessOut.Body.Compact"
@@ -100,7 +112,7 @@
                 android:visibility="gone"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/po_header"
+                app:layout_constraintTop_toBottomOf="@id/po_capture_circular_progress_indicator"
                 tools:text="Please confirm payment in your banking app. Please confirm payment in your banking app."
                 tools:visibility="visible" />
 


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Added native APM configuration property `showPaymentConfirmationProgressIndicatorAfterSeconds` to show the progress indicator during payment confirmation after provided delay.
Recording shows how progress indicator appears after 3 seconds with a custom color and transition background/foreground, following to the success screen.

[napm_loader.webm](https://github.com/processout/processout-android/assets/114916876/d4773014-b86f-49de-85be-79c8703110a4)

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-351
