### PR TITLE
feat(POM-359): Code field in Compose

### DIFF
--- a/ui-core/build.gradle
+++ b/ui-core/build.gradle
@@ -83,6 +83,7 @@ def setBuildConfig(buildType) {
 dependencies {
     api platform("androidx.compose:compose-bom:$androidxComposeBOMVersion")
     api "androidx.compose.material3:material3"
+    api "androidx.lifecycle:lifecycle-runtime-compose:$androidxLifecycleVersion"
     api "androidx.compose.ui:ui-tooling-preview"
     debugApi "androidx.compose.ui:ui-tooling"
 }

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/PORequestFocus.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/PORequestFocus.kt
@@ -1,13 +1,16 @@
-package com.processout.sdk.ui.shared.composable
+package com.processout.sdk.ui.core.component
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.focus.FocusRequester
 import androidx.lifecycle.Lifecycle
+import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 import kotlinx.coroutines.job
 
+/** @suppress */
+@ProcessOutInternalApi
 @Composable
-internal fun RequestFocus(
+fun PORequestFocus(
     focusRequester: FocusRequester,
     lifecycleEvent: Lifecycle.Event? = null
 ) {

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/LabeledFieldLayout.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/LabeledFieldLayout.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import com.processout.sdk.ui.core.component.POExpandableText
 import com.processout.sdk.ui.core.component.POText
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
@@ -14,9 +16,12 @@ internal fun LabeledFieldLayout(
     title: String,
     description: String?,
     style: POFieldLabels.Style = POFieldLabels.default,
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     content: @Composable () -> Unit
 ) {
-    Column {
+    Column(
+        horizontalAlignment = horizontalAlignment
+    ) {
         POText(
             text = title,
             modifier = Modifier.padding(bottom = ProcessOutTheme.spacing.small),
@@ -26,10 +31,23 @@ internal fun LabeledFieldLayout(
         content()
         POExpandableText(
             text = description,
-            style = style.description,
+            style = style.description.copy(
+                textStyle = style.description.textStyle.copy(
+                    textAlign = textAlign(horizontalAlignment)
+                )
+            ),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = ProcessOutTheme.spacing.small)
         )
     }
+}
+
+private fun textAlign(
+    horizontalAlignment: Alignment.Horizontal
+): TextAlign = when (horizontalAlignment) {
+    Alignment.Start -> TextAlign.Start
+    Alignment.CenterHorizontally -> TextAlign.Center
+    Alignment.End -> TextAlign.End
+    else -> TextAlign.Unspecified
 }

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -109,7 +109,7 @@ fun POCodeField(
                                             selection = TextRange(nextText.length)
                                         )
                                     } else {
-                                        textFieldValue.copy()
+                                        textFieldValue.copy(selection = TextRange.Zero)
                                     }
                                 }
                             }
@@ -126,7 +126,7 @@ fun POCodeField(
                                             if (index == textFieldIndex - 1) {
                                                 TextFieldValue()
                                             } else {
-                                                textFieldValue.copy()
+                                                textFieldValue.copy(selection = TextRange.Zero)
                                             }
                                         }
                                         focusManager.moveFocus(FocusDirection.Previous)

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -88,6 +88,19 @@ fun POCodeField(
                                     textFieldValue.copy(selection = TextRange.Zero)
                                 }
                             }
+                            if (textFieldIndex != values.lastIndex && filteredText.length == 2 && it.selection.start == 2) {
+                                val nextText = filteredText.last().toString()
+                                values = values.mapIndexed { index, textFieldValue ->
+                                    if (index == textFieldIndex + 1) {
+                                        TextFieldValue(
+                                            text = nextText,
+                                            selection = TextRange(nextText.length)
+                                        )
+                                    } else {
+                                        textFieldValue.copy()
+                                    }
+                                }
+                            }
                             onValueChange(values.textFieldValue())
                         }
                     },
@@ -101,7 +114,7 @@ fun POCodeField(
                                             if (index == textFieldIndex - 1) {
                                                 TextFieldValue()
                                             } else {
-                                                textFieldValue.copy(selection = TextRange.Zero)
+                                                textFieldValue.copy()
                                             }
                                         }
                                         focusManager.moveFocus(FocusDirection.Previous)

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -28,9 +28,11 @@ import androidx.lifecycle.Lifecycle
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 import com.processout.sdk.ui.core.component.PORequestFocus
 import com.processout.sdk.ui.core.component.field.POField
+import com.processout.sdk.ui.core.component.field.code.POCodeField.style
 import com.processout.sdk.ui.core.component.field.code.POCodeField.validLength
 import com.processout.sdk.ui.core.component.field.text.POTextField
 import com.processout.sdk.ui.core.component.texttoolbar.ProcessOutTextToolbar
+import com.processout.sdk.ui.core.style.POFieldStyle
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
 
 /** @suppress */
@@ -148,7 +150,7 @@ fun POCodeField(
                                 focusedIndex = textFieldIndex
                             }
                         },
-                    style = style,
+                    style = style(style),
                     isError = isError,
                     keyboardOptions = keyboardOptions,
                     keyboardActions = keyboardActions
@@ -218,20 +220,38 @@ object POCodeField {
             copy(
                 normal = normal.copy(
                     text = normal.text.copy(
-                        textStyle = ProcessOutTheme.typography.medium.title.copy(
-                            textAlign = TextAlign.Center
-                        )
+                        textStyle = ProcessOutTheme.typography.medium.title
                     )
                 ),
                 error = error.copy(
                     text = error.text.copy(
-                        textStyle = ProcessOutTheme.typography.medium.title.copy(
-                            textAlign = TextAlign.Center
-                        )
+                        textStyle = ProcessOutTheme.typography.medium.title
                     )
                 )
             )
         }
+
+    @Composable
+    fun custom(style: POFieldStyle) = POField.custom(style)
+
+    internal fun style(style: POField.Style) = with(style) {
+        copy(
+            normal = normal.copy(
+                text = normal.text.copy(
+                    textStyle = normal.text.textStyle.copy(
+                        textAlign = TextAlign.Center
+                    )
+                )
+            ),
+            error = error.copy(
+                text = error.text.copy(
+                    textStyle = error.text.textStyle.copy(
+                        textAlign = TextAlign.Center
+                    )
+                )
+            )
+        )
+    }
 
     internal val LengthMin = 1
     internal val LengthMax = 6

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -37,8 +37,8 @@ fun POCodeField(
     value: TextFieldValue,
     onValueChange: (TextFieldValue) -> Unit,
     modifier: Modifier = Modifier,
-    length: Int = POCodeField.DefaultLength,
     style: POField.Style = POCodeField.default,
+    length: Int = POCodeField.DefaultLength,
     isFocused: Boolean = false,
     lifecycleEvent: Lifecycle.Event? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
@@ -65,7 +65,7 @@ fun POCodeField(
             )
         ) {
             val focusManager = LocalFocusManager.current
-            for (textFieldIndex in 0..<length) {
+            for (textFieldIndex in 0..values.lastIndex) {
                 val focusRequester = remember { FocusRequester() }
                 POTextField(
                     value = values.getOrNull(textFieldIndex) ?: TextFieldValue(),
@@ -122,10 +122,8 @@ fun POCodeField(
                                     false
                                 }
                                 else -> {
-                                    if (it.type == KeyEventType.KeyDown) {
-                                        if (textFieldIndex != length - 1) {
-                                            focusManager.moveFocus(FocusDirection.Next)
-                                        }
+                                    if (it.type == KeyEventType.KeyDown && textFieldIndex != values.lastIndex) {
+                                        focusManager.moveFocus(FocusDirection.Next)
                                     }
                                     false
                                 }

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 import com.processout.sdk.ui.core.component.field.POField
 import com.processout.sdk.ui.core.component.field.text.POTextField
@@ -23,7 +24,7 @@ fun POCodeField(
     onValueChange: (TextFieldValue) -> Unit,
     modifier: Modifier = Modifier,
     length: Int = POCodeField.DefaultLength,
-    style: POField.Style = POField.default
+    style: POField.Style = POCodeField.default
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(ProcessOutTheme.spacing.small)
@@ -101,4 +102,24 @@ private fun rememberDefaultValues(
 object POCodeField {
 
     internal val DefaultLength = 6
+
+    val default: POField.Style
+        @Composable get() = with(POField.default) {
+            copy(
+                normal = normal.copy(
+                    text = normal.text.copy(
+                        textStyle = ProcessOutTheme.typography.medium.title.copy(
+                            textAlign = TextAlign.Center
+                        )
+                    )
+                ),
+                error = error.copy(
+                    text = error.text.copy(
+                        textStyle = ProcessOutTheme.typography.medium.title.copy(
+                            textAlign = TextAlign.Center
+                        )
+                    )
+                )
+            )
+        }
 }

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -1,0 +1,104 @@
+package com.processout.sdk.ui.core.component.field.code
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
+import com.processout.sdk.ui.core.component.field.POField
+import com.processout.sdk.ui.core.component.field.text.POTextField
+import com.processout.sdk.ui.core.theme.ProcessOutTheme
+
+/** @suppress */
+@ProcessOutInternalApi
+@Composable
+fun POCodeField(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    modifier: Modifier = Modifier,
+    length: Int = POCodeField.DefaultLength,
+    style: POField.Style = POField.default
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(ProcessOutTheme.spacing.small)
+    ) {
+        var values by rememberDefaultValues(value, length)
+        for (textFieldIndex in 0..<length) {
+            POTextField(
+                value = values.getOrNull(textFieldIndex) ?: TextFieldValue(),
+                onValueChange = {
+                    values = values.mapIndexed { valueIndex, textFieldValue ->
+                        if (valueIndex == textFieldIndex) {
+                            val updatedText = it.text.find { it.isDigit() }?.toString() ?: String()
+                            val isTextChanged = textFieldValue.text != updatedText
+                            TextFieldValue(
+                                text = updatedText,
+                                selection = if (isTextChanged) {
+                                    TextRange(updatedText.length)
+                                } else {
+                                    it.selection
+                                }
+                            )
+                        } else {
+                            textFieldValue.copy()
+                        }
+                    }
+                    val updatedText = values.joinToString(separator = String()) { it.text }
+                    onValueChange(TextFieldValue(text = updatedText))
+                },
+                modifier = modifier.requiredWidth(ProcessOutTheme.dimensions.formComponentHeight),
+                style = style,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Next
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun rememberDefaultValues(
+    value: TextFieldValue,
+    length: Int
+): MutableState<List<TextFieldValue>> = remember {
+    val values = if (value.text.isEmpty()) {
+        val list = mutableListOf<TextFieldValue>()
+        for (i in 0..<length) {
+            list.add(TextFieldValue())
+        }
+        list
+    } else {
+        val filteredText = value.text.replace(Regex("\\D"), String()).take(length)
+        var list = filteredText.map {
+            val text = if (it.isDigit()) it.toString() else String()
+            TextFieldValue(
+                text = text,
+                selection = TextRange(text.length)
+            )
+        }
+        if (list.size < length) {
+            val lengthDiff = length - list.size
+            val mutableList = list.toMutableList()
+            for (i in 0..<lengthDiff) {
+                mutableList.add(TextFieldValue())
+            }
+            list = mutableList
+        }
+        list
+    }
+    mutableStateOf(values)
+}
+
+/** @suppress */
+@ProcessOutInternalApi
+object POCodeField {
+
+    internal val DefaultLength = 6
+}

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -42,7 +42,7 @@ fun POCodeField(
     modifier: Modifier = Modifier,
     style: POField.Style = POCodeField.default,
     length: Int = POCodeField.LengthMax,
-    alignment: Alignment.Horizontal = Alignment.CenterHorizontally,
+    horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     isError: Boolean = false,
     isFocused: Boolean = false,
     lifecycleEvent: Lifecycle.Event? = null,
@@ -55,7 +55,7 @@ fun POCodeField(
             .focusGroup(),
         horizontalArrangement = Arrangement.spacedBy(
             space = ProcessOutTheme.spacing.small,
-            alignment = alignment
+            alignment = horizontalAlignment
         ),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -1,4 +1,4 @@
-@file:Suppress("MayBeConstant")
+@file:Suppress("MayBeConstant", "MemberVisibilityCanBePrivate")
 
 package com.processout.sdk.ui.core.component.field.code
 
@@ -26,6 +26,7 @@ import androidx.lifecycle.Lifecycle
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 import com.processout.sdk.ui.core.component.PORequestFocus
 import com.processout.sdk.ui.core.component.field.POField
+import com.processout.sdk.ui.core.component.field.code.POCodeField.validLength
 import com.processout.sdk.ui.core.component.field.text.POTextField
 import com.processout.sdk.ui.core.component.texttoolbar.ProcessOutTextToolbar
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
@@ -38,7 +39,7 @@ fun POCodeField(
     onValueChange: (TextFieldValue) -> Unit,
     modifier: Modifier = Modifier,
     style: POField.Style = POCodeField.default,
-    length: Int = POCodeField.DefaultLength,
+    length: Int = POCodeField.LengthMax,
     isError: Boolean = false,
     isFocused: Boolean = false,
     lifecycleEvent: Lifecycle.Event? = null,
@@ -49,7 +50,8 @@ fun POCodeField(
         modifier = Modifier.focusGroup(),
         horizontalArrangement = Arrangement.spacedBy(ProcessOutTheme.spacing.small)
     ) {
-        var values by remember { mutableStateOf(values(value, length)) }
+        val validLength by remember { mutableIntStateOf(validLength(length)) }
+        var values by remember { mutableStateOf(values(value, validLength)) }
         var focusedIndex by remember { mutableIntStateOf(values.focusedIndex()) }
         val clipboardManager = LocalClipboardManager.current
         CompositionLocalProvider(
@@ -57,7 +59,7 @@ fun POCodeField(
                 view = LocalView.current,
                 onPasteRequested = {
                     if (clipboardManager.hasText()) {
-                        values = values(TextFieldValue(text = clipboardManager.getText()?.text ?: String()), length)
+                        values = values(TextFieldValue(text = clipboardManager.getText()?.text ?: String()), validLength)
                         focusedIndex = values.focusedIndex()
                         onValueChange(values.textFieldValue())
                     }
@@ -202,8 +204,6 @@ private fun List<TextFieldValue>.textFieldValue() = TextFieldValue(
 @ProcessOutInternalApi
 object POCodeField {
 
-    internal val DefaultLength = 6
-
     val default: POField.Style
         @Composable get() = with(POField.default) {
             copy(
@@ -223,4 +223,14 @@ object POCodeField {
                 )
             )
         }
+
+    internal val LengthMin = 1
+    internal val LengthMax = 6
+
+    internal fun validLength(length: Int): Int {
+        if (length in LengthMin..LengthMax) {
+            return length
+        }
+        return LengthMax
+    }
 }

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -49,6 +49,7 @@ fun POCodeField(
         horizontalArrangement = Arrangement.spacedBy(ProcessOutTheme.spacing.small)
     ) {
         var values by remember { mutableStateOf(values(value, length)) }
+        var focusedIndex by remember { mutableIntStateOf(values.focusedIndex()) }
         val clipboardManager = LocalClipboardManager.current
         CompositionLocalProvider(
             LocalTextToolbar provides ProcessOutTextToolbar(
@@ -56,6 +57,7 @@ fun POCodeField(
                 onPasteRequested = {
                     if (clipboardManager.hasText()) {
                         values = values(TextFieldValue(text = clipboardManager.getText()?.text ?: String()), length)
+                        focusedIndex = values.focusedIndex()
                         onValueChange(values.textFieldValue())
                     }
                 },
@@ -63,7 +65,6 @@ fun POCodeField(
             )
         ) {
             val focusManager = LocalFocusManager.current
-            var focusedIndex by remember { mutableIntStateOf(0) }
             for (textFieldIndex in 0..<length) {
                 val focusRequester = remember { FocusRequester() }
                 POTextField(
@@ -166,6 +167,15 @@ private fun values(
 private fun List<TextFieldValue>.textFieldValue() = TextFieldValue(
     text = joinToString(separator = String()) { it.text }
 )
+
+private fun List<TextFieldValue>.focusedIndex(): Int {
+    forEachIndexed { index, textFieldValue ->
+        if (textFieldValue.text.isEmpty()) {
+            return index
+        }
+    }
+    return lastIndex
+}
 
 /** @suppress */
 @ProcessOutInternalApi

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -71,9 +71,10 @@ fun POCodeField(
                     value = values.getOrNull(textFieldIndex) ?: TextFieldValue(),
                     onValueChange = {
                         if (it.selection.length == 0) {
+                            val filteredText = it.text.replace(Regex("\\D"), String())
                             values = values.mapIndexed { valueIndex, textFieldValue ->
                                 if (valueIndex == textFieldIndex) {
-                                    val updatedText = it.text.find { char -> char.isDigit() }?.toString() ?: String()
+                                    val updatedText = filteredText.firstOrNull()?.toString() ?: String()
                                     val isTextChanged = textFieldValue.text != updatedText
                                     TextFieldValue(
                                         text = updatedText,
@@ -84,7 +85,7 @@ fun POCodeField(
                                         }
                                     )
                                 } else {
-                                    textFieldValue.copy()
+                                    textFieldValue.copy(selection = TextRange.Zero)
                                 }
                             }
                             onValueChange(values.textFieldValue())
@@ -94,14 +95,21 @@ fun POCodeField(
                         .requiredWidth(ProcessOutTheme.dimensions.formComponentHeight)
                         .onPreviewKeyEvent {
                             when {
-                                it.key == Key.Backspace && it.type == KeyEventType.KeyUp -> {
-                                    if (textFieldIndex != 0) {
+                                it.key == Key.Backspace && it.type == KeyEventType.KeyDown -> {
+                                    if (textFieldIndex != 0 && values[textFieldIndex].selection.start == 0) {
+                                        values = values.mapIndexed { index, textFieldValue ->
+                                            if (index == textFieldIndex - 1) {
+                                                TextFieldValue()
+                                            } else {
+                                                textFieldValue.copy(selection = TextRange.Zero)
+                                            }
+                                        }
                                         focusManager.moveFocus(FocusDirection.Previous)
                                     }
                                     false
                                 }
                                 else -> {
-                                    if (it.type == KeyEventType.KeyUp) {
+                                    if (it.type == KeyEventType.KeyDown) {
                                         if (textFieldIndex != length - 1) {
                                             focusManager.moveFocus(FocusDirection.Next)
                                         }

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -163,10 +163,6 @@ private fun values(
     return values
 }
 
-private fun List<TextFieldValue>.textFieldValue() = TextFieldValue(
-    text = joinToString(separator = String()) { it.text }
-)
-
 private fun List<TextFieldValue>.focusedIndex(): Int {
     forEachIndexed { index, textFieldValue ->
         if (textFieldValue.text.isEmpty()) {
@@ -175,6 +171,10 @@ private fun List<TextFieldValue>.focusedIndex(): Int {
     }
     return lastIndex
 }
+
+private fun List<TextFieldValue>.textFieldValue() = TextFieldValue(
+    text = joinToString(separator = String()) { it.text }
+)
 
 /** @suppress */
 @ProcessOutInternalApi

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MayBeConstant")
+
 package com.processout.sdk.ui.core.component.field.code
 
 import androidx.compose.foundation.focusGroup

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -137,29 +137,28 @@ private fun values(
     length: Int
 ): List<TextFieldValue> {
     val values = if (value.text.isEmpty()) {
-        val list = mutableListOf<TextFieldValue>()
-        for (i in 0..<length) {
-            list.add(TextFieldValue())
+        val emptyValues = mutableListOf<TextFieldValue>()
+        while (emptyValues.size < length) {
+            emptyValues.add(TextFieldValue())
         }
-        list
+        emptyValues
     } else {
         val filteredText = value.text.replace(Regex("\\D"), String()).take(length)
-        var list = filteredText.map {
-            val text = if (it.isDigit()) it.toString() else String()
+        val values = filteredText.map {
+            val text = it.toString()
             TextFieldValue(
                 text = text,
                 selection = TextRange(text.length)
             )
         }
-        if (list.size < length) {
-            val lengthDiff = length - list.size
-            val mutableList = list.toMutableList()
-            for (i in 0..<lengthDiff) {
-                mutableList.add(TextFieldValue())
+        val emptyValues = mutableListOf<TextFieldValue>()
+        if (values.size < length) {
+            val lengthDiff = length - values.size
+            while (emptyValues.size < lengthDiff) {
+                emptyValues.add(TextFieldValue())
             }
-            list = mutableList
         }
-        list
+        values + emptyValues
     }
     return values
 }

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -39,6 +39,7 @@ fun POCodeField(
     modifier: Modifier = Modifier,
     style: POField.Style = POCodeField.default,
     length: Int = POCodeField.DefaultLength,
+    isError: Boolean = false,
     isFocused: Boolean = false,
     lifecycleEvent: Lifecycle.Event? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
@@ -118,6 +119,7 @@ fun POCodeField(
                                             }
                                         }
                                         focusManager.moveFocus(FocusDirection.Previous)
+                                        onValueChange(values.textFieldValue())
                                     }
                                     false
                                 }
@@ -136,6 +138,7 @@ fun POCodeField(
                             }
                         },
                     style = style,
+                    isError = isError,
                     keyboardOptions = keyboardOptions,
                     keyboardActions = keyboardActions
                 )

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -77,7 +77,7 @@ fun POCodeField(
             )
         ) {
             val focusManager = LocalFocusManager.current
-            for (textFieldIndex in 0..values.lastIndex) {
+            for (textFieldIndex in values.indices) {
                 val focusRequester = remember { FocusRequester() }
                 POTextField(
                     value = values.getOrNull(textFieldIndex) ?: TextFieldValue(),

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -82,12 +82,7 @@ fun POCodeField(
                     },
                 style = style,
                 keyboardOptions = keyboardOptions,
-                keyboardActions = KeyboardActions(
-                    onDone = keyboardActions.onDone,
-                    onNext = {
-                        focusManager.moveFocus(FocusDirection.Down)
-                    }
-                )
+                keyboardActions = keyboardActions
             )
         }
     }

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -70,9 +70,15 @@ fun POCodeField(
                 view = LocalView.current,
                 onPasteRequested = {
                     if (clipboardManager.hasText()) {
-                        values = values(TextFieldValue(text = clipboardManager.getText()?.text ?: String()), validLength)
-                        focusedIndex = values.focusedIndex()
-                        onValueChange(values.textFieldValue())
+                        val pastedValues = values(
+                            TextFieldValue(text = clipboardManager.getText()?.text ?: String()),
+                            validLength
+                        )
+                        if (!pastedValues.all { it.text.isEmpty() }) {
+                            values = pastedValues
+                            focusedIndex = values.focusedIndex()
+                            onValueChange(values.textFieldValue())
+                        }
                     }
                 },
                 hideUnspecifiedActions = true

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POCodeField.kt
@@ -5,10 +5,12 @@ package com.processout.sdk.ui.core.component.field.code
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
@@ -40,6 +42,7 @@ fun POCodeField(
     modifier: Modifier = Modifier,
     style: POField.Style = POCodeField.default,
     length: Int = POCodeField.LengthMax,
+    alignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     isError: Boolean = false,
     isFocused: Boolean = false,
     lifecycleEvent: Lifecycle.Event? = null,
@@ -47,8 +50,14 @@ fun POCodeField(
     keyboardActions: KeyboardActions = KeyboardActions.Default
 ) {
     Row(
-        modifier = Modifier.focusGroup(),
-        horizontalArrangement = Arrangement.spacedBy(ProcessOutTheme.spacing.small)
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusGroup(),
+        horizontalArrangement = Arrangement.spacedBy(
+            space = ProcessOutTheme.spacing.small,
+            alignment = alignment
+        ),
+        verticalAlignment = Alignment.CenterVertically
     ) {
         val validLength by remember { mutableIntStateOf(validLength(length)) }
         var values by remember { mutableStateOf(values(value, validLength)) }

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POLabeledCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POLabeledCodeField.kt
@@ -24,7 +24,7 @@ fun POLabeledCodeField(
     fieldStyle: POField.Style = POCodeField.default,
     labelsStyle: POFieldLabels.Style = POFieldLabels.default,
     length: Int = POCodeField.LengthMax,
-    alignment: Alignment.Horizontal = Alignment.CenterHorizontally,
+    horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     isError: Boolean = false,
     isFocused: Boolean = false,
     lifecycleEvent: Lifecycle.Event? = null,
@@ -34,7 +34,8 @@ fun POLabeledCodeField(
     LabeledFieldLayout(
         title = title,
         description = description,
-        style = labelsStyle
+        style = labelsStyle,
+        horizontalAlignment = horizontalAlignment
     ) {
         POCodeField(
             value = value,
@@ -42,7 +43,7 @@ fun POLabeledCodeField(
             modifier = modifier,
             style = fieldStyle,
             length = length,
-            alignment = alignment,
+            horizontalAlignment = horizontalAlignment,
             isError = isError,
             isFocused = isFocused,
             lifecycleEvent = lifecycleEvent,

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POLabeledCodeField.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/field/code/POLabeledCodeField.kt
@@ -1,0 +1,53 @@
+package com.processout.sdk.ui.core.component.field.code
+
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.lifecycle.Lifecycle
+import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
+import com.processout.sdk.ui.core.component.field.LabeledFieldLayout
+import com.processout.sdk.ui.core.component.field.POField
+import com.processout.sdk.ui.core.component.field.POFieldLabels
+
+/** @suppress */
+@ProcessOutInternalApi
+@Composable
+fun POLabeledCodeField(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    title: String,
+    description: String?,
+    modifier: Modifier = Modifier,
+    fieldStyle: POField.Style = POCodeField.default,
+    labelsStyle: POFieldLabels.Style = POFieldLabels.default,
+    length: Int = POCodeField.LengthMax,
+    alignment: Alignment.Horizontal = Alignment.CenterHorizontally,
+    isError: Boolean = false,
+    isFocused: Boolean = false,
+    lifecycleEvent: Lifecycle.Event? = null,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default
+) {
+    LabeledFieldLayout(
+        title = title,
+        description = description,
+        style = labelsStyle
+    ) {
+        POCodeField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = modifier,
+            style = fieldStyle,
+            length = length,
+            alignment = alignment,
+            isError = isError,
+            isFocused = isFocused,
+            lifecycleEvent = lifecycleEvent,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions
+        )
+    }
+}

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/texttoolbar/FloatingTextActionModeCallback.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/texttoolbar/FloatingTextActionModeCallback.kt
@@ -1,0 +1,44 @@
+package com.processout.sdk.ui.core.component.texttoolbar
+
+import android.graphics.Rect
+import android.view.ActionMode
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import androidx.annotation.RequiresApi
+
+@RequiresApi(23)
+internal class FloatingTextActionModeCallback(
+    private val callback: TextActionModeCallback
+) : ActionMode.Callback2() {
+
+    override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+        return callback.onCreateActionMode(mode, menu)
+    }
+
+    override fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+        return callback.onPrepareActionMode(mode, menu)
+    }
+
+    override fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
+        return callback.onActionItemClicked(mode, item)
+    }
+
+    override fun onDestroyActionMode(mode: ActionMode?) {
+        callback.onDestroyActionMode()
+    }
+
+    override fun onGetContentRect(
+        mode: ActionMode?,
+        view: View?,
+        outRect: Rect?
+    ) {
+        val rect = callback.rect
+        outRect?.set(
+            rect.left.toInt(),
+            rect.top.toInt(),
+            rect.right.toInt(),
+            rect.bottom.toInt()
+        )
+    }
+}

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/texttoolbar/PrimaryTextActionModeCallback.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/texttoolbar/PrimaryTextActionModeCallback.kt
@@ -1,0 +1,26 @@
+package com.processout.sdk.ui.core.component.texttoolbar
+
+import android.view.ActionMode
+import android.view.Menu
+import android.view.MenuItem
+
+internal class PrimaryTextActionModeCallback(
+    private val callback: TextActionModeCallback
+) : ActionMode.Callback {
+
+    override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+        return callback.onCreateActionMode(mode, menu)
+    }
+
+    override fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+        return callback.onPrepareActionMode(mode, menu)
+    }
+
+    override fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
+        return callback.onActionItemClicked(mode, item)
+    }
+
+    override fun onDestroyActionMode(mode: ActionMode?) {
+        callback.onDestroyActionMode()
+    }
+}

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/texttoolbar/ProcessOutTextToolbar.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/texttoolbar/ProcessOutTextToolbar.kt
@@ -1,0 +1,71 @@
+package com.processout.sdk.ui.core.component.texttoolbar
+
+import android.os.Build
+import android.view.ActionMode
+import android.view.View
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.TextToolbar
+import androidx.compose.ui.platform.TextToolbarStatus
+
+internal class ProcessOutTextToolbar(
+    private val view: View,
+    private val onCopyRequested: (() -> Unit)? = null,
+    private val onPasteRequested: (() -> Unit)? = null,
+    private val onCutRequested: (() -> Unit)? = null,
+    private val onSelectAllRequested: (() -> Unit)? = null,
+    private val hideUnspecifiedActions: Boolean = false
+) : TextToolbar {
+
+    private var actionMode: ActionMode? = null
+
+    private val textActionModeCallback = TextActionModeCallback(
+        onActionModeDestroy = {
+            actionMode = null
+        }
+    )
+
+    override var status = TextToolbarStatus.Hidden
+        private set
+
+    override fun showMenu(
+        rect: Rect,
+        onCopyRequested: (() -> Unit)?,
+        onPasteRequested: (() -> Unit)?,
+        onCutRequested: (() -> Unit)?,
+        onSelectAllRequested: (() -> Unit)?
+    ) {
+        textActionModeCallback.rect = rect
+        if (hideUnspecifiedActions) {
+            textActionModeCallback.onCopyRequested = this.onCopyRequested
+            textActionModeCallback.onPasteRequested = this.onPasteRequested
+            textActionModeCallback.onCutRequested = this.onCutRequested
+            textActionModeCallback.onSelectAllRequested = this.onSelectAllRequested
+        } else {
+            textActionModeCallback.onCopyRequested = this.onCopyRequested ?: onCopyRequested
+            textActionModeCallback.onPasteRequested = this.onPasteRequested ?: onPasteRequested
+            textActionModeCallback.onCutRequested = this.onCutRequested ?: onCutRequested
+            textActionModeCallback.onSelectAllRequested = this.onSelectAllRequested ?: onSelectAllRequested
+        }
+        if (actionMode == null) {
+            actionMode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                view.startActionMode(
+                    FloatingTextActionModeCallback(textActionModeCallback),
+                    ActionMode.TYPE_FLOATING
+                )
+            } else {
+                view.startActionMode(
+                    PrimaryTextActionModeCallback(textActionModeCallback)
+                )
+            }
+            status = TextToolbarStatus.Shown
+        } else {
+            actionMode?.invalidate()
+        }
+    }
+
+    override fun hide() {
+        actionMode?.finish()
+        actionMode = null
+        status = TextToolbarStatus.Hidden
+    }
+}

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/texttoolbar/TextActionModeCallback.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/texttoolbar/TextActionModeCallback.kt
@@ -1,0 +1,99 @@
+package com.processout.sdk.ui.core.component.texttoolbar
+
+import android.view.ActionMode
+import android.view.Menu
+import android.view.MenuItem
+import androidx.compose.ui.geometry.Rect
+
+internal class TextActionModeCallback(
+    var rect: Rect = Rect.Zero,
+    var onCopyRequested: (() -> Unit)? = null,
+    var onPasteRequested: (() -> Unit)? = null,
+    var onCutRequested: (() -> Unit)? = null,
+    var onSelectAllRequested: (() -> Unit)? = null,
+    val onActionModeDestroy: (() -> Unit)? = null
+) {
+
+    fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+        if (mode == null || menu == null) {
+            return false
+        }
+        onCopyRequested?.let {
+            addMenuItem(menu, MenuItemOption.Copy)
+        }
+        onPasteRequested?.let {
+            addMenuItem(menu, MenuItemOption.Paste)
+        }
+        onCutRequested?.let {
+            addMenuItem(menu, MenuItemOption.Cut)
+        }
+        onSelectAllRequested?.let {
+            addMenuItem(menu, MenuItemOption.SelectAll)
+        }
+        return true
+    }
+
+    fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+        if (mode == null || menu == null) {
+            return false
+        }
+        updateMenuItems(menu)
+        return true
+    }
+
+    fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
+        when (item?.itemId) {
+            MenuItemOption.Copy.id -> onCopyRequested?.invoke()
+            MenuItemOption.Paste.id -> onPasteRequested?.invoke()
+            MenuItemOption.Cut.id -> onCutRequested?.invoke()
+            MenuItemOption.SelectAll.id -> onSelectAllRequested?.invoke()
+            else -> return false
+        }
+        mode?.finish()
+        return true
+    }
+
+    fun onDestroyActionMode() {
+        onActionModeDestroy?.invoke()
+    }
+
+    private fun updateMenuItems(menu: Menu) {
+        addOrRemoveMenuItem(menu, MenuItemOption.Copy, onCopyRequested)
+        addOrRemoveMenuItem(menu, MenuItemOption.Paste, onPasteRequested)
+        addOrRemoveMenuItem(menu, MenuItemOption.Cut, onCutRequested)
+        addOrRemoveMenuItem(menu, MenuItemOption.SelectAll, onSelectAllRequested)
+    }
+
+    private fun addOrRemoveMenuItem(
+        menu: Menu,
+        item: MenuItemOption,
+        callback: (() -> Unit)?
+    ) {
+        when {
+            callback != null && menu.findItem(item.id) == null -> addMenuItem(menu, item)
+            callback == null && menu.findItem(item.id) != null -> menu.removeItem(item.id)
+        }
+    }
+
+    private fun addMenuItem(menu: Menu, item: MenuItemOption) {
+        menu.add(0, item.id, item.order, item.titleResource)
+            .setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM)
+    }
+}
+
+private enum class MenuItemOption(val id: Int) {
+    Copy(0),
+    Paste(1),
+    Cut(2),
+    SelectAll(3);
+
+    val titleResource: Int
+        get() = when (this) {
+            Copy -> android.R.string.copy
+            Paste -> android.R.string.paste
+            Cut -> android.R.string.cut
+            SelectAll -> android.R.string.selectAll
+        }
+
+    val order = id
+}

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -90,7 +90,6 @@ dependencies {
     api project(path: ':ui-core')
 
     api "androidx.activity:activity-compose:$androidxActivityVersion"
-    api "androidx.lifecycle:lifecycle-runtime-compose:$androidxLifecycleVersion"
     api "androidx.lifecycle:lifecycle-viewmodel-compose:$androidxLifecycleVersion"
 
     api "com.google.android.gms:play-services-wallet:$gmsWalletVersion"

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationScreen.kt
@@ -22,10 +22,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.lifecycle.Lifecycle
 import com.processout.sdk.ui.card.tokenization.CardTokenizationEvent.*
 import com.processout.sdk.ui.card.tokenization.CardTokenizationViewModelState.Item
-import com.processout.sdk.ui.core.component.POActionsContainer
-import com.processout.sdk.ui.core.component.POExpandableText
-import com.processout.sdk.ui.core.component.POHeader
-import com.processout.sdk.ui.core.component.POText
+import com.processout.sdk.ui.core.component.*
 import com.processout.sdk.ui.core.component.field.POField
 import com.processout.sdk.ui.core.component.field.dropdown.PODropdownField
 import com.processout.sdk.ui.core.component.field.text.POTextField
@@ -35,7 +32,6 @@ import com.processout.sdk.ui.core.state.POImmutableList
 import com.processout.sdk.ui.core.style.POAxis
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
 import com.processout.sdk.ui.shared.composable.AnimatedImage
-import com.processout.sdk.ui.shared.composable.RequestFocus
 import com.processout.sdk.ui.shared.composable.rememberLifecycleEvent
 
 @Composable
@@ -219,7 +215,7 @@ private fun TextField(
         )
     )
     if (state.id == focusedFieldId && lifecycleEvent == Lifecycle.Event.ON_RESUME) {
-        RequestFocus(focusRequester, lifecycleEvent)
+        PORequestFocus(focusRequester, lifecycleEvent)
     }
 }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateScreen.kt
@@ -20,10 +20,7 @@ import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.colorResource
 import androidx.lifecycle.Lifecycle
 import com.processout.sdk.ui.card.update.CardUpdateEvent.*
-import com.processout.sdk.ui.core.component.POActionsContainer
-import com.processout.sdk.ui.core.component.POExpandableText
-import com.processout.sdk.ui.core.component.POHeader
-import com.processout.sdk.ui.core.component.POText
+import com.processout.sdk.ui.core.component.*
 import com.processout.sdk.ui.core.component.field.POField
 import com.processout.sdk.ui.core.component.field.text.POTextField
 import com.processout.sdk.ui.core.state.POActionState
@@ -32,7 +29,6 @@ import com.processout.sdk.ui.core.state.POImmutableList
 import com.processout.sdk.ui.core.style.POAxis
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
 import com.processout.sdk.ui.shared.composable.AnimatedImage
-import com.processout.sdk.ui.shared.composable.RequestFocus
 import com.processout.sdk.ui.shared.composable.rememberLifecycleEvent
 
 @Composable
@@ -142,7 +138,7 @@ private fun Fields(
             )
         )
         if (state.id == focusedFieldId && lifecycleEvent == Lifecycle.Event.ON_RESUME) {
-            RequestFocus(focusRequester, lifecycleEvent)
+            PORequestFocus(focusRequester, lifecycleEvent)
         }
     }
 }


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
`POCodeField` and `POLabeledCodeField` with custom `ProcessOutTextToolbar` that allows to `Paste` and disable other actions. `PORequestFocus` and its `lifecycle` dependency moved to `ui-core` module.

[code_field_compose.webm](https://github.com/processout/processout-android/assets/114916876/23e6d647-055c-42fc-869e-26a31a376e78)

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-359
