### PR TITLE
fix(ad-hoc): Catch Google Pay API exception

### DIFF
--- a/ui/src/main/kotlin/com/processout/sdk/ui/googlepay/GooglePayService.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/googlepay/GooglePayService.kt
@@ -1,12 +1,14 @@
 package com.processout.sdk.ui.googlepay
 
 import android.app.Application
+import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.wallet.IsReadyToPayRequest
 import com.google.android.gms.wallet.PaymentData
 import com.google.android.gms.wallet.PaymentDataRequest
 import com.google.android.gms.wallet.Wallet
 import com.google.android.gms.wallet.Wallet.WalletOptions
+import com.processout.sdk.core.logger.POLogger
 import kotlinx.coroutines.tasks.await
 import org.json.JSONObject
 
@@ -17,10 +19,14 @@ internal class GooglePayService(
 
     private val client = Wallet.getPaymentsClient(application, walletOptions)
 
-    suspend fun isReadyToPay(isReadyToPayRequestJson: JSONObject): Boolean {
-        val request = IsReadyToPayRequest.fromJson(isReadyToPayRequestJson.toString())
-        return client.isReadyToPay(request).await()
-    }
+    suspend fun isReadyToPay(isReadyToPayRequestJson: JSONObject): Boolean =
+        try {
+            val request = IsReadyToPayRequest.fromJson(isReadyToPayRequestJson.toString())
+            client.isReadyToPay(request).await()
+        } catch (e: ApiException) {
+            POLogger.warn("Google Pay API exception when checking readiness: %s", e)
+            false
+        }
 
     fun loadPaymentData(paymentDataRequestJson: JSONObject): Task<PaymentData> {
         val request = PaymentDataRequest.fromJson(paymentDataRequestJson.toString())


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Google Pay API throws an exception when checking readiness on the device where it's not available:

`com.google.android.gms.common.api.ApiException: 17: API: Wallet.API is not available on this device. Connection failed with: ConnectionResult{statusCode=SERVICE_INVALID, resolution=null, message=null}`

Catching and logging.