### PR TITLE
fix(ad-hoc): Refactor coroutine scopes

### DIFF
--- a/sdk/src/main/kotlin/com/processout/sdk/api/preferences/Preferences.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/preferences/Preferences.kt
@@ -4,12 +4,15 @@ import android.content.Context
 import androidx.core.content.edit
 import com.processout.sdk.BuildConfig
 import com.processout.sdk.di.ContextGraph
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.util.UUID
 
 internal class Preferences(
     contextGraph: ContextGraph,
-    scope: CoroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob()),
+    scope: CoroutineScope = contextGraph.mainScope,
     workDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
 

--- a/sdk/src/main/kotlin/com/processout/sdk/api/repository/BaseRepository.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/repository/BaseRepository.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MemberVisibilityCanBePrivate")
-
 package com.processout.sdk.api.repository
 
 import com.processout.sdk.core.*
@@ -13,14 +11,14 @@ import java.net.SocketTimeoutException
 
 internal abstract class BaseRepository(
     private val failureMapper: ApiFailureMapper,
+    protected val repositoryScope: CoroutineScope,
+    private val workDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val retryStrategy: PORetryStrategy = Exponential(
         maxRetries = 4,
         initialDelay = 100,
         maxDelay = 1000,
         factor = 3.0
-    ),
-    protected val repositoryScope: CoroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob()),
-    protected val workDispatcher: CoroutineDispatcher = Dispatchers.IO
+    )
 ) {
 
     protected suspend fun <T : Any> apiCall(

--- a/sdk/src/main/kotlin/com/processout/sdk/api/repository/DefaultCardsRepository.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/repository/DefaultCardsRepository.kt
@@ -14,7 +14,7 @@ internal class DefaultCardsRepository(
     failureMapper: ApiFailureMapper,
     private val api: CardsApi,
     private val contextGraph: ContextGraph
-) : BaseRepository(failureMapper), POCardsRepository {
+) : BaseRepository(failureMapper, contextGraph.mainScope), POCardsRepository {
 
     override suspend fun tokenize(
         request: POCardTokenizationRequest

--- a/sdk/src/main/kotlin/com/processout/sdk/api/repository/DefaultCustomerTokensRepository.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/repository/DefaultCustomerTokensRepository.kt
@@ -14,7 +14,7 @@ internal class DefaultCustomerTokensRepository(
     failureMapper: ApiFailureMapper,
     private val api: CustomerTokensApi,
     private val contextGraph: ContextGraph
-) : BaseRepository(failureMapper), CustomerTokensRepository {
+) : BaseRepository(failureMapper, contextGraph.mainScope), CustomerTokensRepository {
 
     override suspend fun assignCustomerToken(
         request: POAssignCustomerTokenRequest

--- a/sdk/src/main/kotlin/com/processout/sdk/api/repository/DefaultGatewayConfigurationsRepository.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/repository/DefaultGatewayConfigurationsRepository.kt
@@ -8,11 +8,13 @@ import com.processout.sdk.api.model.response.POGatewayConfiguration
 import com.processout.sdk.api.network.GatewayConfigurationsApi
 import com.processout.sdk.core.ProcessOutCallback
 import com.processout.sdk.core.map
+import kotlinx.coroutines.CoroutineScope
 
 internal class DefaultGatewayConfigurationsRepository(
     failureMapper: ApiFailureMapper,
+    repositoryScope: CoroutineScope,
     private val api: GatewayConfigurationsApi
-) : BaseRepository(failureMapper), POGatewayConfigurationsRepository {
+) : BaseRepository(failureMapper, repositoryScope), POGatewayConfigurationsRepository {
 
     override suspend fun fetch(
         request: POAllGatewayConfigurationsRequest

--- a/sdk/src/main/kotlin/com/processout/sdk/api/repository/DefaultInvoicesRepository.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/repository/DefaultInvoicesRepository.kt
@@ -13,7 +13,7 @@ internal class DefaultInvoicesRepository(
     failureMapper: ApiFailureMapper,
     private val api: InvoicesApi,
     private val contextGraph: ContextGraph
-) : BaseRepository(failureMapper), InvoicesRepository {
+) : BaseRepository(failureMapper, contextGraph.mainScope), InvoicesRepository {
 
     override suspend fun authorizeInvoice(
         request: POInvoiceAuthorizationRequest

--- a/sdk/src/main/kotlin/com/processout/sdk/api/repository/DefaultTelemetryRepository.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/repository/DefaultTelemetryRepository.kt
@@ -2,11 +2,13 @@ package com.processout.sdk.api.repository
 
 import com.processout.sdk.api.model.request.TelemetryRequest
 import com.processout.sdk.api.network.TelemetryApi
+import kotlinx.coroutines.CoroutineScope
 
 internal class DefaultTelemetryRepository(
     failureMapper: ApiFailureMapper,
+    repositoryScope: CoroutineScope,
     private val api: TelemetryApi
-) : BaseRepository(failureMapper), TelemetryRepository {
+) : BaseRepository(failureMapper, repositoryScope), TelemetryRepository {
 
     override suspend fun send(request: TelemetryRequest) =
         apiCall { api.send(request) }

--- a/sdk/src/main/kotlin/com/processout/sdk/api/service/TelemetryService.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/service/TelemetryService.kt
@@ -21,9 +21,9 @@ import kotlinx.coroutines.launch
 
 internal class TelemetryService(
     minimumLevel: POLogLevel,
-    private val scope: CoroutineScope,
     private val repository: TelemetryRepository,
-    private val contextGraph: ContextGraph
+    private val contextGraph: ContextGraph,
+    private val scope: CoroutineScope = contextGraph.mainScope
 ) : BaseLoggerService(minimumLevel) {
 
     override fun log(event: LogEvent) {

--- a/sdk/src/main/kotlin/com/processout/sdk/api/service/proxy3ds/PODefaultProxy3DSService.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/service/proxy3ds/PODefaultProxy3DSService.kt
@@ -8,12 +8,15 @@ import com.processout.sdk.api.model.threeds.PO3DSRedirect
 import com.processout.sdk.api.service.proxy3ds.POProxy3DSServiceRequest.*
 import com.processout.sdk.core.ProcessOutResult
 import com.processout.sdk.core.annotation.ProcessOutInternalApi
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 /** @suppress */
 @ProcessOutInternalApi
 class PODefaultProxy3DSService(
-    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+    private val scope: CoroutineScope = MainScope(),
     private val eventDispatcher: POEventDispatcher = POEventDispatcher
 ) : POProxy3DSService {
 

--- a/sdk/src/main/kotlin/com/processout/sdk/core/coroutine/POCloseableCoroutineScope.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/core/coroutine/POCloseableCoroutineScope.kt
@@ -8,11 +8,9 @@ import kotlin.coroutines.CoroutineContext
 
 /** @suppress */
 @ProcessOutInternalApi
-class POCloseableCoroutineScope(context: CoroutineContext) : Closeable, CoroutineScope {
+class POCloseableCoroutineScope(
+    override val coroutineContext: CoroutineContext
+) : Closeable, CoroutineScope {
 
-    override val coroutineContext: CoroutineContext = context
-
-    override fun close() {
-        coroutineContext.cancel()
-    }
+    override fun close() = coroutineContext.cancel()
 }

--- a/sdk/src/main/kotlin/com/processout/sdk/di/ContextGraph.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/di/ContextGraph.kt
@@ -8,10 +8,13 @@ import androidx.core.content.ContextCompat
 import com.processout.sdk.api.ProcessOutConfiguration
 import com.processout.sdk.api.model.request.DeviceData
 import com.processout.sdk.core.locale.currentAppLocale
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
 import java.util.Calendar
 
 internal interface ContextGraph {
     var configuration: ProcessOutConfiguration
+    val mainScope: CoroutineScope
     val deviceData: DeviceData
 }
 
@@ -23,6 +26,8 @@ internal class DefaultContextGraph(
     override var configuration: ProcessOutConfiguration = configuration
         @Synchronized get
         @Synchronized set
+
+    override val mainScope: CoroutineScope = MainScope()
 
     override val deviceData: DeviceData
         get() = provideDeviceData()

--- a/sdk/src/main/kotlin/com/processout/sdk/di/RepositoryGraph.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/di/RepositoryGraph.kt
@@ -20,7 +20,7 @@ internal class DefaultRepositoryGraph(
         get() = ApiFailureMapper(adapter = networkGraph.moshi.adapter(POFailure.ApiError::class.java))
 
     override val gatewayConfigurationsRepository: POGatewayConfigurationsRepository by lazy {
-        DefaultGatewayConfigurationsRepository(failureMapper, networkGraph.gatewayConfigurationsApi)
+        DefaultGatewayConfigurationsRepository(failureMapper, contextGraph.mainScope, networkGraph.gatewayConfigurationsApi)
     }
 
     override val invoicesRepository: InvoicesRepository by lazy {
@@ -36,6 +36,6 @@ internal class DefaultRepositoryGraph(
     }
 
     override val telemetryRepository: TelemetryRepository by lazy {
-        DefaultTelemetryRepository(failureMapper, networkGraph.telemetryApi)
+        DefaultTelemetryRepository(failureMapper, contextGraph.mainScope, networkGraph.telemetryApi)
     }
 }

--- a/sdk/src/main/kotlin/com/processout/sdk/di/ServiceGraph.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/di/ServiceGraph.kt
@@ -4,9 +4,6 @@ import com.processout.sdk.api.service.*
 import com.processout.sdk.core.logger.POLogLevel
 import com.processout.sdk.core.logger.POLoggerService
 import com.processout.sdk.core.logger.SystemLoggerService
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 
 internal interface ServiceGraph {
     val invoicesService: POInvoicesService
@@ -24,16 +21,13 @@ internal class DefaultServiceGraph(
     alternativePaymentMethodsBaseUrl: String
 ) : ServiceGraph {
 
-    private val mainCoroutineScope: CoroutineScope
-        get() = CoroutineScope(Dispatchers.Main + SupervisorJob())
-
     private val threeDSService: ThreeDSService by lazy {
         DefaultThreeDSService(networkGraph.moshi)
     }
 
     override val invoicesService: POInvoicesService by lazy {
         DefaultInvoicesService(
-            mainCoroutineScope,
+            contextGraph.mainScope,
             repositoryGraph.invoicesRepository,
             threeDSService
         )
@@ -41,7 +35,7 @@ internal class DefaultServiceGraph(
 
     override val customerTokensService: POCustomerTokensService by lazy {
         DefaultCustomerTokensService(
-            mainCoroutineScope,
+            contextGraph.mainScope,
             repositoryGraph.customerTokensRepository,
             threeDSService
         )
@@ -62,7 +56,6 @@ internal class DefaultServiceGraph(
     override val telemetryService: POLoggerService by lazy {
         TelemetryService(
             minimumLevel = POLogLevel.WARN,
-            scope = mainCoroutineScope,
             repository = repositoryGraph.telemetryRepository,
             contextGraph = contextGraph
         )

--- a/ui/src/main/kotlin/com/processout/sdk/ui/googlepay/POGooglePayCardTokenizationLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/googlepay/POGooglePayCardTokenizationLauncher.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.wallet.PaymentData
@@ -27,8 +28,6 @@ import com.processout.sdk.core.logger.POLogger
 import com.processout.sdk.core.onFailure
 import com.processout.sdk.ui.shared.extension.orElse
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 
@@ -52,7 +51,7 @@ class POGooglePayCardTokenizationLauncher private constructor(
         ) = POGooglePayCardTokenizationLauncher(
             launcher = from.registerForActivityResult(
                 TaskResultContracts.GetPaymentDataResult(),
-                ActivityResultHandler(callback)
+                ActivityResultHandler(from.lifecycleScope, callback)
             ),
             service = GooglePayService(
                 application = from.requireActivity().application,
@@ -72,7 +71,7 @@ class POGooglePayCardTokenizationLauncher private constructor(
             launcher = from.registerForActivityResult(
                 TaskResultContracts.GetPaymentDataResult(),
                 from.activityResultRegistry,
-                ActivityResultHandler(callback)
+                ActivityResultHandler(from.lifecycleScope, callback)
             ),
             service = GooglePayService(
                 application = from.application,
@@ -101,10 +100,10 @@ class POGooglePayCardTokenizationLauncher private constructor(
     }
 
     private class ActivityResultHandler(
+        private val scope: CoroutineScope,
         private val callback: (ProcessOutResult<POGooglePayCardTokenizationData>) -> Unit,
         private val cards: POCardsRepository = ProcessOut.instance.cards,
-        private val mapper: PaymentDataMapper = PaymentDataMapper(),
-        private val scope: CoroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+        private val mapper: PaymentDataMapper = PaymentDataMapper()
     ) : ActivityResultCallback<ApiTaskResult<PaymentData>> {
 
         override fun onActivityResult(result: ApiTaskResult<PaymentData>) {


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Refactored usages of coroutine scopes to apply the following rules:
1) Created `mainScope` in `ContextGraph`. It used in all services and repositories whose scope should be active throughout the whole SDK/app lifetime. It never cancels.
2) `Dispatchers.Main.immediate` used only in components responsible to update the UI (activity/VM/interactor) and bound to component lifecycle.
3) Short lived components (like `PODefaultProxy3DSService`) have it's own `MainScope()` which is cancelled when component is not needed anymore.
4) Other components will use the scope of parent component whenever possible (e.g. launchers use `lifecycleScope`).