### PR TITLE
fix(ad-hoc): Prevent starting of nAPM and Card Tokenization on Android configuration changes

### DIFF
--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
@@ -72,6 +72,10 @@ internal class CardTokenizationInteractor(
     //region Initialization
 
     fun start() {
+        if (_state.value.started) {
+            return
+        }
+        _state.update { it.copy(started = true) }
         interactorScope.launch {
             POLogger.info("Starting card tokenization.")
             dispatch(WillStart)
@@ -86,6 +90,9 @@ internal class CardTokenizationInteractor(
     }
 
     fun start(configuration: POCardTokenizationConfiguration) {
+        if (_state.value.started) {
+            return
+        }
         this.configuration = configuration
         _state.update { initState() }
         start()

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractorState.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractorState.kt
@@ -7,6 +7,7 @@ import com.processout.sdk.ui.core.state.POAvailableValue
 import com.processout.sdk.ui.shared.provider.address.AddressSpecification
 
 internal data class CardTokenizationInteractorState(
+    val started: Boolean = false,
     val cardFields: List<Field>,
     val addressFields: List<Field>,
     val addressSpecification: AddressSpecification? = null,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
@@ -79,7 +79,7 @@ internal class NativeAlternativePaymentInteractor(
     private val _completion = MutableStateFlow<NativeAlternativePaymentCompletion>(Awaiting)
     val completion = _completion.asStateFlow()
 
-    private val _state = MutableStateFlow<NativeAlternativePaymentInteractorState>(Loading)
+    private val _state = MutableStateFlow<NativeAlternativePaymentInteractorState>(Idle)
     val state = _state.asStateFlow()
 
     private val handler = Handler(Looper.getMainLooper())
@@ -90,6 +90,10 @@ internal class NativeAlternativePaymentInteractor(
     private var capturePassedTimestamp = 0L
 
     fun start() {
+        if (_state.value !is Idle) {
+            return
+        }
+        _state.update { Loading }
         POLogger.info("Starting native alternative payment.")
         dispatch(WillStart)
         dispatchFailure()
@@ -101,6 +105,9 @@ internal class NativeAlternativePaymentInteractor(
         invoiceId: String,
         gatewayConfigurationId: String
     ) {
+        if (_state.value !is Idle) {
+            return
+        }
         this.invoiceId = invoiceId
         this.gatewayConfigurationId = gatewayConfigurationId
         logAttributes = logAttributes(
@@ -117,7 +124,7 @@ internal class NativeAlternativePaymentInteractor(
         captureStartTimestamp = 0L
         capturePassedTimestamp = 0L
         _completion.update { Awaiting }
-        _state.update { Loading }
+        _state.update { Idle }
     }
 
     private fun fetchTransactionDetails() {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractorState.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractorState.kt
@@ -12,6 +12,8 @@ internal sealed interface NativeAlternativePaymentInteractorState {
 
     //region States
 
+    data object Idle : NativeAlternativePaymentInteractorState
+
     data object Loading : NativeAlternativePaymentInteractorState
 
     data class Loaded(

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModel.kt
@@ -113,7 +113,7 @@ internal class NativeAlternativePaymentViewModel private constructor(
     private fun map(
         state: NativeAlternativePaymentInteractorState
     ): NativeAlternativePaymentViewModelState = when (state) {
-        Loading -> loading()
+        Idle, Loading -> loading()
         is UserInput -> state.map()
         is Capturing -> state.map()
         is Captured -> state.map()


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Standalone Compose implementations of nAPM and Card Tokenization are started explicitly in `onAttach()` method of their respective `BottomSheetDialogFragment`.
`onAttach()` method is called again on Android configuration changes (e.g. dark/light theme, language, etc...) causing `viewModel.start()` to be called again as well, leading to inconsistent state and sending of redundant lifecycle events.
This PR prevents subsequential starts when flow is already started.