### PR TITLE
feat(POM-422): Support nAPM payment confirmation

### DIFF
--- a/example/src/main/kotlin/com/processout/example/ui/screen/checkout/DynamicCheckoutFragment.kt
+++ b/example/src/main/kotlin/com/processout/example/ui/screen/checkout/DynamicCheckoutFragment.kt
@@ -24,6 +24,8 @@ import com.processout.sdk.core.onFailure
 import com.processout.sdk.core.onSuccess
 import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration
 import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration.AlternativePaymentConfiguration
+import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration.AlternativePaymentConfiguration.PaymentConfirmationConfiguration
+import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration.AlternativePaymentConfiguration.PaymentConfirmationConfiguration.ConfirmButton
 import com.processout.sdk.ui.checkout.PODynamicCheckoutLauncher
 import com.processout.sdk.ui.shared.view.dialog.POAlertDialog
 import com.processout.sdk.ui.threeds.PO3DSRedirectCustomTabLauncher
@@ -94,7 +96,10 @@ class DynamicCheckoutFragment : BaseFragment<FragmentDynamicCheckoutBinding>(
                     clientSecret = uiModel.clientSecret
                 ),
                 alternativePayment = AlternativePaymentConfiguration(
-                    returnUrl = Constants.RETURN_URL
+                    returnUrl = Constants.RETURN_URL,
+                    paymentConfirmation = PaymentConfirmationConfiguration(
+                        confirmButton = ConfirmButton()
+                    )
                 )
             )
         )

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PONativeAlternativePaymentMethodEvent.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PONativeAlternativePaymentMethodEvent.kt
@@ -68,6 +68,12 @@ sealed class PONativeAlternativePaymentMethodEvent {
     ) : PONativeAlternativePaymentMethodEvent()
 
     /**
+     * Event is sent during the capture stage when the user confirms that they have completed
+     * any required external actions. Implementation proceeds with the actual capture process.
+     */
+    data object DidConfirmPayment : PONativeAlternativePaymentMethodEvent()
+
+    /**
      * Event is sent when user asked to confirm cancellation, e.g. via dialog.
      */
     data object DidRequestCancelConfirmation : PONativeAlternativePaymentMethodEvent()

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PONativeAlternativePaymentMethodEvent.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PONativeAlternativePaymentMethodEvent.kt
@@ -68,8 +68,8 @@ sealed class PONativeAlternativePaymentMethodEvent {
     ) : PONativeAlternativePaymentMethodEvent()
 
     /**
-     * Event is sent during the capture stage when the user confirms that they have completed
-     * any required external actions. Implementation proceeds with the actual capture process.
+     * Event is sent during the capture stage when the user confirms that they have completed required external action.
+     * Implementation proceeds with the actual capture process.
      */
     data object DidConfirmPayment : PONativeAlternativePaymentMethodEvent()
 

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodUiState.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodUiState.kt
@@ -45,6 +45,7 @@ internal data class NativeAlternativePaymentMethodUiModel(
     val customerActionImageUrl: String?,
     val primaryActionText: String,
     val secondaryAction: SecondaryActionUiModel?,
+    val paymentConfirmationPrimaryActionText: String?,
     val paymentConfirmationSecondaryAction: SecondaryActionUiModel?,
     val isPaymentConfirmationProgressIndicatorVisible: Boolean,
     val isSubmitting: Boolean

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
@@ -412,12 +412,14 @@ internal class NativeAlternativePaymentMethodViewModel private constructor(
         POLogger.info("All payment parameters has been submitted.")
 
         if (options.waitsPaymentConfirmation) {
+            val customerActionMessage = parameterValues?.customerActionMessage ?: uiModel.customerActionMessageMarkdown
             val updatedUiModel = uiModel.copy(
                 title = parameterValues?.providerName,
                 logoUrl = if (parameterValues?.providerName != null)
                     parameterValues.providerLogoUrl else uiModel.logoUrl,
-                customerActionMessageMarkdown = parameterValues?.customerActionMessage
-                    ?: uiModel.customerActionMessageMarkdown
+                customerActionMessageMarkdown = customerActionMessage,
+                paymentConfirmationPrimaryActionText = if (!customerActionMessage.isNullOrBlank())
+                    uiModel.paymentConfirmationPrimaryActionText else null
             )
             POLogger.info("Waiting for capture confirmation.")
             dispatch(
@@ -433,7 +435,7 @@ internal class NativeAlternativePaymentMethodViewModel private constructor(
             updatedUiModel.paymentConfirmationSecondaryAction?.let {
                 scheduleSecondaryActionEnabling(it) { enablePaymentConfirmationSecondaryAction() }
             }
-            if (options.paymentConfirmationPrimaryAction == null) {
+            if (updatedUiModel.paymentConfirmationPrimaryActionText == null) {
                 capture()
             }
             return

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
@@ -631,7 +631,7 @@ internal class NativeAlternativePaymentMethodViewModel private constructor(
             primaryActionText = options.primaryActionText ?: invoice.formatPrimaryActionText(),
             secondaryAction = options.secondaryAction?.toUiModel(),
             paymentConfirmationPrimaryActionText = options.paymentConfirmationPrimaryAction?.let {
-                it.text ?: app.getString(R.string.po_native_apm_confirm_capture_button_text)
+                it.text ?: app.getString(R.string.po_native_apm_confirm_payment_button_text)
             },
             paymentConfirmationSecondaryAction = options.paymentConfirmationSecondaryAction?.toUiModel(),
             isPaymentConfirmationProgressIndicatorVisible = false,

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
@@ -616,6 +616,9 @@ internal class NativeAlternativePaymentMethodViewModel private constructor(
             customerActionImageUrl = gateway.customerActionImageUrl,
             primaryActionText = options.primaryActionText ?: invoice.formatPrimaryActionText(),
             secondaryAction = options.secondaryAction?.toUiModel(),
+            paymentConfirmationPrimaryActionText = options.paymentConfirmationPrimaryAction?.let {
+                it.text ?: app.getString(R.string.po_native_apm_confirm_capture_button_text)
+            },
             paymentConfirmationSecondaryAction = options.paymentConfirmationSecondaryAction?.toUiModel(),
             isPaymentConfirmationProgressIndicatorVisible = false,
             isSubmitting = false

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
@@ -501,6 +501,8 @@ internal class NativeAlternativePaymentMethodViewModel private constructor(
 
     fun confirmPayment() {
         _uiState.value.doWhenCapture { uiModel ->
+            POLogger.info("User confirmed that required external actions are complete.")
+            dispatch(DidConfirmPayment)
             _uiState.value = Capture(
                 uiModel.copy(paymentConfirmationPrimaryActionText = null)
             )

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
@@ -501,7 +501,7 @@ internal class NativeAlternativePaymentMethodViewModel private constructor(
 
     fun confirmPayment() {
         _uiState.value.doWhenCapture { uiModel ->
-            POLogger.info("User confirmed that required external actions are complete.")
+            POLogger.info("User confirmed that required external action is complete.")
             dispatch(DidConfirmPayment)
             _uiState.value = Capture(
                 uiModel.copy(paymentConfirmationPrimaryActionText = null)

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/NativeAlternativePaymentMethodViewModel.kt
@@ -516,13 +516,13 @@ internal class NativeAlternativePaymentMethodViewModel private constructor(
         if (captureStartTimestamp != 0L) {
             return
         }
+        captureStartTimestamp = System.currentTimeMillis()
+        options.showPaymentConfirmationProgressIndicatorAfterSeconds?.let { afterSeconds ->
+            showPaymentConfirmationProgressIndicator(
+                afterMillis = TimeUnit.SECONDS.toMillis(afterSeconds.toLong())
+            )
+        }
         viewModelScope.launch {
-            captureStartTimestamp = System.currentTimeMillis()
-            options.showPaymentConfirmationProgressIndicatorAfterSeconds?.let { afterSeconds ->
-                showPaymentConfirmationProgressIndicator(
-                    afterMillis = TimeUnit.SECONDS.toMillis(afterSeconds.toLong())
-                )
-            }
             val iterator = captureRetryStrategy.iterator
             while (capturePassedTimestamp < options.paymentConfirmationTimeoutSeconds * 1000) {
                 val result = invoicesService.captureNativeAlternativePayment(invoiceId, gatewayConfigurationId)

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodBottomSheet.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodBottomSheet.kt
@@ -501,6 +501,11 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment(),
         viewModel.submitPayment()
     }
 
+    private fun onConfirmPaymentClick() {
+        bindingCapture.poPrimaryButton.isClickable = false
+        viewModel.confirmPayment()
+    }
+
     private fun onCancelClick(confirmation: ActionConfirmation) {
         with(confirmation) {
             if (!enabled) {
@@ -672,9 +677,7 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment(),
             bindingCapture.poFooter.visibility = View.VISIBLE
             with(bindingCapture.poPrimaryButton) {
                 uiModel.paymentConfirmationPrimaryActionText?.let { actionText ->
-                    setOnClickListener {
-                        // TODO
-                    }
+                    setOnClickListener { onConfirmPaymentClick() }
                     text = actionText
                     visibility = View.VISIBLE
                 } ?: run { visibility = View.GONE }

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodBottomSheet.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodBottomSheet.kt
@@ -17,15 +17,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import android.widget.LinearLayout
 import androidx.activity.addCallback
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.animation.addListener
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.children
-import androidx.core.view.updateLayoutParams
+import androidx.core.view.*
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -586,7 +584,7 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment(),
 
     private fun bindCapture(uiModel: NativeAlternativePaymentMethodUiModel) {
         initCaptureView()
-        bindPaymentConfirmationSecondaryButton(uiModel)
+        bindCaptureFooter(uiModel)
         if (uiModel.showCustomerAction()) {
             bindingCapture.poCircularProgressIndicator.visibility = View.GONE
             if (uiModel.isPaymentConfirmationProgressIndicatorVisible) {
@@ -665,21 +663,44 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment(),
         bindingCapture.poMessage.visibility = View.VISIBLE
     }
 
-    private fun bindPaymentConfirmationSecondaryButton(
+    private fun bindCaptureFooter(
         uiModel: NativeAlternativePaymentMethodUiModel
     ) {
-        uiModel.paymentConfirmationSecondaryAction?.let { action ->
-            with(bindingCapture.poSecondaryButton) {
-                when (action) {
-                    is SecondaryActionUiModel.Cancel -> {
-                        setOnClickListener { onCancelClick(action.confirmation) }
-                        text = action.text
-                        setState(action.state)
-                        bindingCapture.poFooter.visibility = View.VISIBLE
+        val visible = uiModel.paymentConfirmationPrimaryActionText != null
+                || uiModel.paymentConfirmationSecondaryAction != null
+        if (visible) {
+            bindingCapture.poFooter.visibility = View.VISIBLE
+            with(bindingCapture.poPrimaryButton) {
+                uiModel.paymentConfirmationPrimaryActionText?.let { actionText ->
+                    setOnClickListener {
+                        // TODO
                     }
-                }
+                    text = actionText
+                    visibility = View.VISIBLE
+                } ?: run { visibility = View.GONE }
             }
-        } ?: run { bindingCapture.poFooter.visibility = View.GONE }
+            with(bindingCapture.poSecondaryButton) {
+                uiModel.paymentConfirmationSecondaryAction?.let { action ->
+                    when (action) {
+                        is SecondaryActionUiModel.Cancel -> {
+                            setOnClickListener { onCancelClick(action.confirmation) }
+                            if (uiModel.paymentConfirmationPrimaryActionText == null) {
+                                updateLayoutParams<LinearLayout.LayoutParams> {
+                                    updateMarginsRelative(
+                                        top = resources.getDimensionPixelSize(R.dimen.po_bottomSheet_buttons_marginVertical)
+                                    )
+                                }
+                            }
+                            text = action.text
+                            setState(action.state)
+                            visibility = View.VISIBLE
+                        }
+                    }
+                } ?: run { visibility = View.GONE }
+            }
+        } else {
+            bindingCapture.poFooter.visibility = View.GONE
+        }
     }
 
     private fun handleSuccess(uiModel: NativeAlternativePaymentMethodUiModel) {

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodBottomSheet.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodBottomSheet.kt
@@ -776,6 +776,7 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment(),
         bindingCapture.poFooter.visibility = View.GONE
     }
 
+    @Suppress("DEPRECATION")
     private fun bindSuccessBackground() {
         val backgroundDecorationSuccessColor =
             when (val stateStyle = configuration?.style?.backgroundDecoration?.success) {

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodConfiguration.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodConfiguration.kt
@@ -45,6 +45,8 @@ data class PONativeAlternativePaymentMethodConfiguration(
      * or will complete right after all user’s input is submitted. Default value is _true_.
      * @param[paymentConfirmationTimeoutSeconds] Amount of time (in seconds) to wait for final payment confirmation.
      * Default value is 3 minutes, while maximum value is 15 minutes.
+     * @param[paymentConfirmationPrimaryAction] Optional primary action for payment confirmation.
+     * To hide action use _null_, this is a default behaviour.
      * @param[paymentConfirmationSecondaryAction] Action that could be optionally presented to user during payment confirmation stage.
      * To hide action use _null_, this is a default behaviour.
      * @param[showPaymentConfirmationProgressIndicatorAfterSeconds] Show progress indicator during payment confirmation after provided delay (in seconds).
@@ -61,6 +63,7 @@ data class PONativeAlternativePaymentMethodConfiguration(
         val skipSuccessScreen: Boolean = false,
         val waitsPaymentConfirmation: Boolean = true,
         val paymentConfirmationTimeoutSeconds: Int = DEFAULT_PAYMENT_CONFIRMATION_TIMEOUT_SECONDS,
+        val paymentConfirmationPrimaryAction: ConfirmAction? = null,
         val paymentConfirmationSecondaryAction: SecondaryAction? = null,
         val showPaymentConfirmationProgressIndicatorAfterSeconds: Int? = null
     ) : Parcelable {
@@ -69,6 +72,16 @@ data class PONativeAlternativePaymentMethodConfiguration(
             const val DEFAULT_PAYMENT_CONFIRMATION_TIMEOUT_SECONDS = 3 * 60
         }
     }
+
+    /**
+     * Action for confirmation.
+     *
+     * @param[text] Action text. Pass _null_ to use default text.
+     */
+    @Parcelize
+    data class ConfirmAction(
+        val text: String? = null
+    ) : Parcelable
 
     /**
      * Supported secondary actions.

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodConfiguration.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodConfiguration.kt
@@ -93,6 +93,7 @@ data class PONativeAlternativePaymentMethodConfiguration(
          * @param[text] Action text. Pass _null_ to use default text.
          * @param[disabledForSeconds] Initially disables action for the given amount of time in seconds.
          * By default user can interact with action immediately when it's visible.
+         * @param[confirmation] Specifies action confirmation configuration (e.g. dialog). Disabled by default.
          */
         @Parcelize
         data class Cancel(
@@ -103,9 +104,9 @@ data class PONativeAlternativePaymentMethodConfiguration(
     }
 
     /**
-     * Specifies action confirmation behaviour and values.
+     * Specifies action confirmation configuration (e.g. dialog).
      *
-     * @param[enabled] Enables action confirmation.
+     * @param[enabled] Enables action confirmation. Default value is _false_.
      * @param[title] Custom title. Pass _null_ to use default text.
      * @param[message] Custom message. Pass _null_ to use default text. Pass empty string to hide.
      * @param[confirmActionText] Custom confirm action text. Pass _null_ to use default text.

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/StyleCustomization.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/StyleCustomization.kt
@@ -30,6 +30,7 @@ import com.processout.sdk.ui.shared.style.radio.PORadioButtonStyle
 import com.processout.sdk.ui.shared.view.extension.dpToPx
 import com.processout.sdk.ui.shared.view.extension.spToPx
 
+@Suppress("DEPRECATION")
 internal fun PoBottomSheetNativeApmBinding.applyStyle(
     style: PONativeAlternativePaymentMethodConfiguration.Style
 ) {
@@ -51,6 +52,7 @@ internal fun PoBottomSheetCaptureBinding.applyStyle(
     }
     style.successImageResId?.let { poSuccessImage.setImageResource(it) }
     style.message?.let { poMessage.applyStyle(it) }
+    style.primaryButton?.let { poPrimaryButton.applyStyle(it) }
     style.secondaryButton?.let { poSecondaryButton.applyStyle(it) }
     style.controlsTintColor?.let {
         poMessage.applyControlsTintColor(it)

--- a/sdk/src/main/res/layout/po_bottom_sheet_capture.xml
+++ b/sdk/src/main/res/layout/po_bottom_sheet_capture.xml
@@ -172,7 +172,7 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/po_bottomSheet_buttons_marginHorizontal"
             android:layout_marginTop="@dimen/po_bottomSheet_buttons_marginVertical"
-            android:text="@string/po_native_apm_confirm_capture_button_text"
+            android:text="@string/po_native_apm_confirm_payment_button_text"
             android:visibility="gone"
             tools:visibility="visible" />
 

--- a/sdk/src/main/res/layout/po_bottom_sheet_capture.xml
+++ b/sdk/src/main/res/layout/po_bottom_sheet_capture.xml
@@ -151,6 +151,7 @@
         android:id="@+id/po_footer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/po_bottomSheet_buttons_marginVertical"
         android:orientation="vertical"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -165,14 +166,26 @@
             android:background="@color/po_border_subtle" />
 
         <com.processout.sdk.ui.shared.view.button.POButton
+            android:id="@+id/po_primary_button"
+            style="@style/Widget.ProcessOut.Button.Primary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/po_bottomSheet_buttons_marginHorizontal"
+            android:layout_marginTop="@dimen/po_bottomSheet_buttons_marginVertical"
+            android:text="@string/po_native_apm_confirm_capture_button_text"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+        <com.processout.sdk.ui.shared.view.button.POButton
             android:id="@+id/po_secondary_button"
             style="@style/Widget.ProcessOut.Button.Secondary"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/po_bottomSheet_buttons_marginHorizontal"
-            android:layout_marginTop="@dimen/po_bottomSheet_buttons_marginVertical"
-            android:layout_marginBottom="@dimen/po_bottomSheet_buttons_marginVertical"
-            android:text="@string/po_native_apm_cancel_button_text" />
+            android:layout_marginTop="@dimen/po_button_marginTop"
+            android:text="@string/po_native_apm_cancel_button_text"
+            android:visibility="gone"
+            tools:visibility="visible" />
     </LinearLayout>
 
 </merge>

--- a/sdk/src/main/res/values-ar/strings.xml
+++ b/sdk/src/main/res/values-ar/strings.xml
@@ -15,6 +15,7 @@
     <string name="po_native_apm_submit_button_text_format">الدفع %s</string>
     <string name="po_native_apm_submit_button_text">الدفع</string>
     <string name="po_native_apm_cancel_button_text">إلغاء</string>
+    <string name="po_native_apm_confirm_capture_button_text">لقد دفعت</string>
     <string name="po_native_apm_email_placeholder">name@example.com</string>
     <string name="po_native_apm_phone_placeholder">أدخل رقم الهاتف</string>
     <string name="po_native_apm_success_message">نجاح! تمت الموافقة على الدفع</string>

--- a/sdk/src/main/res/values-ar/strings.xml
+++ b/sdk/src/main/res/values-ar/strings.xml
@@ -15,7 +15,7 @@
     <string name="po_native_apm_submit_button_text_format">الدفع %s</string>
     <string name="po_native_apm_submit_button_text">الدفع</string>
     <string name="po_native_apm_cancel_button_text">إلغاء</string>
-    <string name="po_native_apm_confirm_capture_button_text">لقد دفعت</string>
+    <string name="po_native_apm_confirm_payment_button_text">لقد دفعت</string>
     <string name="po_native_apm_email_placeholder">name@example.com</string>
     <string name="po_native_apm_phone_placeholder">أدخل رقم الهاتف</string>
     <string name="po_native_apm_success_message">نجاح! تمت الموافقة على الدفع</string>

--- a/sdk/src/main/res/values-fr/strings.xml
+++ b/sdk/src/main/res/values-fr/strings.xml
@@ -15,7 +15,7 @@
     <string name="po_native_apm_submit_button_text_format">Payer %s</string>
     <string name="po_native_apm_submit_button_text">Payer</string>
     <string name="po_native_apm_cancel_button_text">Annuler</string>
-    <string name="po_native_apm_confirm_capture_button_text">J\'ai payé</string>
+    <string name="po_native_apm_confirm_payment_button_text">J\'ai payé</string>
     <string name="po_native_apm_email_placeholder">nom@exemple.fr</string>
     <string name="po_native_apm_phone_placeholder">Entrez votre numéro de téléphone</string>
     <string name="po_native_apm_success_message">Succès !\nPaiement confirmé.</string>

--- a/sdk/src/main/res/values-fr/strings.xml
+++ b/sdk/src/main/res/values-fr/strings.xml
@@ -15,6 +15,7 @@
     <string name="po_native_apm_submit_button_text_format">Payer %s</string>
     <string name="po_native_apm_submit_button_text">Payer</string>
     <string name="po_native_apm_cancel_button_text">Annuler</string>
+    <string name="po_native_apm_confirm_capture_button_text">J\'ai payé</string>
     <string name="po_native_apm_email_placeholder">nom@exemple.fr</string>
     <string name="po_native_apm_phone_placeholder">Entrez votre numéro de téléphone</string>
     <string name="po_native_apm_success_message">Succès !\nPaiement confirmé.</string>

--- a/sdk/src/main/res/values-pl/strings.xml
+++ b/sdk/src/main/res/values-pl/strings.xml
@@ -15,7 +15,7 @@
     <string name="po_native_apm_submit_button_text_format">Zapłać %s</string>
     <string name="po_native_apm_submit_button_text">Zapłać</string>
     <string name="po_native_apm_cancel_button_text">Anuluj</string>
-    <string name="po_native_apm_confirm_capture_button_text">Płatność wykonana</string>
+    <string name="po_native_apm_confirm_payment_button_text">Płatność wykonana</string>
     <string name="po_native_apm_email_placeholder">imię@przykład.pl</string>
     <string name="po_native_apm_phone_placeholder">Twój numer telefonu</string>
     <string name="po_native_apm_success_message">Sukces!\nPłatność przyjęta.</string>

--- a/sdk/src/main/res/values-pl/strings.xml
+++ b/sdk/src/main/res/values-pl/strings.xml
@@ -15,6 +15,7 @@
     <string name="po_native_apm_submit_button_text_format">Zapłać %s</string>
     <string name="po_native_apm_submit_button_text">Zapłać</string>
     <string name="po_native_apm_cancel_button_text">Anuluj</string>
+    <string name="po_native_apm_confirm_capture_button_text">Płatność wykonana</string>
     <string name="po_native_apm_email_placeholder">imię@przykład.pl</string>
     <string name="po_native_apm_phone_placeholder">Twój numer telefonu</string>
     <string name="po_native_apm_success_message">Sukces!\nPłatność przyjęta.</string>

--- a/sdk/src/main/res/values-pt/strings.xml
+++ b/sdk/src/main/res/values-pt/strings.xml
@@ -15,6 +15,7 @@
     <string name="po_native_apm_submit_button_text_format">Pagar %s</string>
     <string name="po_native_apm_submit_button_text">Pagar</string>
     <string name="po_native_apm_cancel_button_text">Cancelar</string>
+    <string name="po_native_apm_confirm_capture_button_text">Já paguei</string>
     <string name="po_native_apm_email_placeholder">nome@exemplo.pt</string>
     <string name="po_native_apm_phone_placeholder">Insira o seu número de telemóvel</string>
     <string name="po_native_apm_success_message">Successo!\nPagamento aprovado.</string>

--- a/sdk/src/main/res/values-pt/strings.xml
+++ b/sdk/src/main/res/values-pt/strings.xml
@@ -15,7 +15,7 @@
     <string name="po_native_apm_submit_button_text_format">Pagar %s</string>
     <string name="po_native_apm_submit_button_text">Pagar</string>
     <string name="po_native_apm_cancel_button_text">Cancelar</string>
-    <string name="po_native_apm_confirm_capture_button_text">Já paguei</string>
+    <string name="po_native_apm_confirm_payment_button_text">Já paguei</string>
     <string name="po_native_apm_email_placeholder">nome@exemplo.pt</string>
     <string name="po_native_apm_phone_placeholder">Insira o seu número de telemóvel</string>
     <string name="po_native_apm_success_message">Successo!\nPagamento aprovado.</string>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="po_native_apm_submit_button_text_format">Pay %s</string>
     <string name="po_native_apm_submit_button_text">Pay</string>
     <string name="po_native_apm_cancel_button_text">Cancel</string>
-    <string name="po_native_apm_confirm_capture_button_text">I\'ve paid</string>
+    <string name="po_native_apm_confirm_payment_button_text">I\'ve paid</string>
     <string name="po_native_apm_email_placeholder">name@example.com</string>
     <string name="po_native_apm_phone_placeholder">Enter phone number</string>
     <string name="po_native_apm_success_message">Success!\nPayment approved.</string>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="po_native_apm_submit_button_text_format">Pay %s</string>
     <string name="po_native_apm_submit_button_text">Pay</string>
     <string name="po_native_apm_cancel_button_text">Cancel</string>
+    <string name="po_native_apm_confirm_capture_button_text">I\'ve paid</string>
     <string name="po_native_apm_email_placeholder">name@example.com</string>
     <string name="po_native_apm_phone_placeholder">Enter phone number</string>
     <string name="po_native_apm_success_message">Success!\nPayment approved.</string>

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
@@ -114,6 +114,7 @@ internal class DynamicCheckoutActivity : BaseTransparentPortraitActivity() {
                 timeoutSeconds = paymentConfirmation?.timeoutSeconds ?: DEFAULT_TIMEOUT_SECONDS,
                 showProgressIndicatorAfterSeconds = paymentConfirmation?.showProgressIndicatorAfterSeconds,
                 hideGatewayDetails = true,
+                primaryAction = paymentConfirmation?.confirmButton?.let { ConfirmAction(text = it.text) },
                 secondaryAction = paymentConfirmation?.cancelButton?.toSecondaryAction()
             ),
             inlineSingleSelectValuesLimit = configuration?.alternativePayment?.inlineSingleSelectValuesLimit ?: 5,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
@@ -95,8 +95,15 @@ data class PODynamicCheckoutConfiguration(
         data class PaymentConfirmationConfiguration(
             val timeoutSeconds: Int = 3 * 60,
             val showProgressIndicatorAfterSeconds: Int? = null,
+            val confirmButton: ConfirmButton? = null,
             val cancelButton: CancelButton? = CancelButton()
-        ) : Parcelable
+        ) : Parcelable {
+
+            @Parcelize
+            data class ConfirmButton(
+                val text: String? = null
+            ) : Parcelable
+        }
     }
 
     @Parcelize

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/NativeAlternativePayment.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/NativeAlternativePayment.kt
@@ -23,6 +23,7 @@ import com.processout.sdk.ui.checkout.screen.DynamicCheckoutScreen.LongAnimation
 import com.processout.sdk.ui.checkout.screen.DynamicCheckoutScreen.ShortAnimationDurationMillis
 import com.processout.sdk.ui.checkout.screen.DynamicCheckoutScreen.isMessageShort
 import com.processout.sdk.ui.checkout.screen.DynamicCheckoutScreen.messageGravity
+import com.processout.sdk.ui.core.component.POButton
 import com.processout.sdk.ui.core.component.POCircularProgressIndicator
 import com.processout.sdk.ui.core.component.PORequestFocus
 import com.processout.sdk.ui.core.component.POText
@@ -56,7 +57,7 @@ internal fun NativeAlternativePayment(
     when (state) {
         is UserInput -> UserInput(id, state, onEvent, style)
         is Capture -> if (!state.isCaptured) {
-            Capture(state, style)
+            Capture(id, state, onEvent, style)
         }
         else -> {}
     }
@@ -321,7 +322,9 @@ private fun DropdownField(
 
 @Composable
 private fun Capture(
+    id: String,
     state: Capture,
+    onEvent: (DynamicCheckoutEvent) -> Unit,
     style: DynamicCheckoutScreen.Style
 ) {
     AnimatedVisibility(
@@ -369,6 +372,21 @@ private fun Capture(
                     onError = {
                         showImage = false
                     }
+                )
+            }
+            state.primaryAction?.let { action ->
+                POButton(
+                    text = action.text,
+                    onClick = {
+                        onEvent(
+                            Action(
+                                actionId = action.id,
+                                paymentMethodId = id
+                            )
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    style = style.actionsContainer.primary
                 )
             }
         }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
@@ -653,18 +653,17 @@ internal class NativeAlternativePaymentInteractor(
         }
         interactorScope.launch {
             POLogger.info("Waiting for capture confirmation.")
-            dispatch(
-                WillWaitForCaptureConfirmation(
-                    additionalActionExpected = !stateValue.actionMessage.isNullOrBlank()
-                )
-            )
+            val additionalActionExpected = !stateValue.actionMessage.isNullOrBlank()
+            dispatch(WillWaitForCaptureConfirmation(additionalActionExpected = additionalActionExpected))
             preloadAllImages(
                 stateValue = stateValue,
                 coroutineScope = this@launch
             )
             _state.update { Capturing(stateValue) }
             enableCapturingSecondaryAction()
-            capture()
+            if (!additionalActionExpected || options.paymentConfirmation.primaryAction == null) {
+                capture()
+            }
         }
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
@@ -663,7 +663,6 @@ internal class NativeAlternativePaymentInteractor(
                 coroutineScope = this@launch
             )
             _state.update { Capturing(stateValue) }
-            enableCapturingProgressIndicator()
             enableCapturingSecondaryAction()
             capture()
         }
@@ -679,6 +678,7 @@ internal class NativeAlternativePaymentInteractor(
         }
         interactorScope.launch {
             captureStartTimestamp = System.currentTimeMillis()
+            enableCapturingProgressIndicator()
             val iterator = captureRetryStrategy.iterator
             while (capturePassedTimestamp < options.paymentConfirmation.timeoutSeconds * 1000) {
                 val result = invoicesService.captureNativeAlternativePayment(invoiceId, gatewayConfigurationId)

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
@@ -192,6 +192,7 @@ internal class NativeAlternativePaymentInteractor(
         actionImageUrl = gateway.customerActionImageUrl,
         actionMessage = parameterValues?.customerActionMessage
             ?: gateway.customerActionMessage?.let { escapedMarkdown(it) },
+        primaryActionId = ActionId.CONFIRM_PAYMENT,
         secondaryAction = NativeAlternativePaymentInteractorState.Action(
             id = ActionId.CANCEL,
             enabled = false
@@ -398,6 +399,7 @@ internal class NativeAlternativePaymentInteractor(
             is Action -> when (event.id) {
                 ActionId.SUBMIT -> submit()
                 ActionId.CANCEL -> cancel()
+                ActionId.CONFIRM_PAYMENT -> confirmPayment()
             }
             is ActionConfirmationRequested -> {
                 POLogger.debug("Requested the user to confirm the action: %s", event.id)
@@ -665,6 +667,10 @@ internal class NativeAlternativePaymentInteractor(
             enableCapturingSecondaryAction()
             capture()
         }
+    }
+
+    private fun confirmPayment() {
+        // TODO
     }
 
     private fun capture() {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
@@ -680,9 +680,9 @@ internal class NativeAlternativePaymentInteractor(
         if (captureStartTimestamp != 0L) {
             return
         }
+        captureStartTimestamp = System.currentTimeMillis()
+        enableCapturingProgressIndicator()
         interactorScope.launch {
-            captureStartTimestamp = System.currentTimeMillis()
-            enableCapturingProgressIndicator()
             val iterator = captureRetryStrategy.iterator
             while (capturePassedTimestamp < options.paymentConfirmation.timeoutSeconds * 1000) {
                 val result = invoicesService.captureNativeAlternativePayment(invoiceId, gatewayConfigurationId)

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
@@ -668,7 +668,12 @@ internal class NativeAlternativePaymentInteractor(
     }
 
     private fun confirmPayment() {
-        // TODO
+        _state.whenCapturing { stateValue ->
+            POLogger.info("User confirmed that required external action is complete.")
+            dispatch(DidConfirmPayment)
+            _state.update { Capturing(stateValue.copy(primaryActionId = null)) }
+            capture()
+        }
     }
 
     private fun capture() {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractorState.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractorState.kt
@@ -54,7 +54,7 @@ internal sealed interface NativeAlternativePaymentInteractorState {
         val logoUrl: String?,
         val actionImageUrl: String?,
         val actionMessage: String?,
-        val primaryActionId: String,
+        val primaryActionId: String?,
         val secondaryAction: Action,
         val withProgressIndicator: Boolean
     )

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractorState.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractorState.kt
@@ -54,6 +54,7 @@ internal sealed interface NativeAlternativePaymentInteractorState {
         val logoUrl: String?,
         val actionImageUrl: String?,
         val actionMessage: String?,
+        val primaryActionId: String,
         val secondaryAction: Action,
         val withProgressIndicator: Boolean
     )
@@ -79,6 +80,7 @@ internal sealed interface NativeAlternativePaymentInteractorState {
     object ActionId {
         const val SUBMIT = "submit"
         const val CANCEL = "cancel"
+        const val CONFIRM_PAYMENT = "confirm-payment"
     }
 }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentScreen.kt
@@ -527,7 +527,10 @@ private fun Actions(
             primary = state.primaryAction
             secondary = state.secondaryAction
         }
-        is Capture -> secondary = state.secondaryAction
+        is Capture -> {
+            primary = state.primaryAction
+            secondary = state.secondaryAction
+        }
     }
     val actions = mutableListOf<POActionState>()
     primary?.let { actions.add(it) }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModel.kt
@@ -154,11 +154,13 @@ internal class NativeAlternativePaymentViewModel private constructor(
             )
         } else {
             val primaryAction = options.paymentConfirmation.primaryAction?.let {
-                POActionState(
-                    id = primaryActionId,
-                    text = it.text ?: app.getString(R.string.po_native_apm_confirm_payment_button_text),
-                    primary = true
-                )
+                primaryActionId?.let { id ->
+                    POActionState(
+                        id = id,
+                        text = it.text ?: app.getString(R.string.po_native_apm_confirm_payment_button_text),
+                        primary = true
+                    )
+                }
             }
             NativeAlternativePaymentViewModelState.Capture(
                 title = paymentProviderName,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModel.kt
@@ -153,11 +153,19 @@ internal class NativeAlternativePaymentViewModel private constructor(
                 secondaryAction = secondaryAction
             )
         } else {
+            val primaryAction = options.paymentConfirmation.primaryAction?.let {
+                POActionState(
+                    id = primaryActionId,
+                    text = it.text ?: app.getString(R.string.po_native_apm_confirm_payment_button_text),
+                    primary = true
+                )
+            }
             NativeAlternativePaymentViewModelState.Capture(
                 title = paymentProviderName,
                 logoUrl = logoUrl,
                 imageUrl = actionImageUrl,
                 message = actionMessage,
+                primaryAction = primaryAction,
                 secondaryAction = secondaryAction,
                 withProgressIndicator = withProgressIndicator,
                 isCaptured = false
@@ -171,6 +179,7 @@ internal class NativeAlternativePaymentViewModel private constructor(
             logoUrl = logoUrl,
             imageUrl = null,
             message = options.successMessage ?: app.getString(R.string.po_native_apm_success_message),
+            primaryAction = null,
             secondaryAction = null,
             withProgressIndicator = false,
             isCaptured = true

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModelState.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModelState.kt
@@ -30,6 +30,7 @@ internal sealed interface NativeAlternativePaymentViewModelState {
         val logoUrl: String?,
         val imageUrl: String?,
         val message: String,
+        val primaryAction: POActionState?,
         val secondaryAction: POActionState?,
         val withProgressIndicator: Boolean,
         val isCaptured: Boolean

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentConfiguration.kt
@@ -59,6 +59,8 @@ data class PONativeAlternativePaymentConfiguration(
          * @param[text] Action text. Pass _null_ to use default text.
          * @param[disabledForSeconds] Initially disables action for the given amount of time in seconds.
          * By default user can interact with action immediately when it's visible.
+         * @param[confirmation] Specifies action confirmation configuration (e.g. dialog).
+         * Use _null_ to disable, this is a default behaviour.
          */
         @Parcelize
         data class Cancel(

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentConfiguration.kt
@@ -50,6 +50,16 @@ data class PONativeAlternativePaymentConfiguration(
     ) : Parcelable
 
     /**
+     * Action for confirmation.
+     *
+     * @param[text] Action text. Pass _null_ to use default text.
+     */
+    @Parcelize
+    data class ConfirmAction(
+        val text: String? = null
+    ) : Parcelable
+
+    /**
      * Supported secondary actions.
      */
     sealed class SecondaryAction : Parcelable {
@@ -95,6 +105,8 @@ data class PONativeAlternativePaymentConfiguration(
      * Use _null_ to hide, this is a default behaviour.
      * @param[hideGatewayDetails] Specifies whether gateway information (such as name/logo) should be hidden during payment confirmation
      * even when specific payment provider details are not available. Default value is _false_.
+     * @param[primaryAction] Optional primary action for payment confirmation.
+     * To hide action use _null_, this is a default behaviour.
      * @param[secondaryAction] Secondary action (e.g. "Cancel") that could be optionally presented to user during payment confirmation stage.
      * Use _null_ to hide, this is a default behaviour.
      */
@@ -104,6 +116,7 @@ data class PONativeAlternativePaymentConfiguration(
         val timeoutSeconds: Int = DEFAULT_TIMEOUT_SECONDS,
         val showProgressIndicatorAfterSeconds: Int? = null,
         val hideGatewayDetails: Boolean = false,
+        val primaryAction: ConfirmAction? = null,
         val secondaryAction: SecondaryAction? = null
     ) : Parcelable {
         companion object {


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Added optional payment confirmation button for native APM implementations: Views, Compose, Dynamic Checkout.
Button is visible when enabled in configuration and there is required customer action during capture stage.
Clicking on the button starts capture polling.
Added `DidConfirmPayment` event which is sent on button click.

[napm_paid_button_compose.webm](https://github.com/user-attachments/assets/685d2986-79b4-46c6-abad-9622ba031b3d)

[napm_paid_button_views.webm](https://github.com/user-attachments/assets/5745c5a3-39e5-4018-9c62-4b12480d5d71)

[dc_paid_button.webm](https://github.com/user-attachments/assets/7350640f-da6b-443d-a892-e182e6954f96)

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-422
