### PR TITLE
feat(POM-424): Support Android 15 enforced edge-to-edge with backwards compatibility

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -2,4 +2,5 @@
 /shelf/
 /workspace.xml
 /deploymentTargetDropDown.xml
+/runConfigurations.xml
 /other.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ ext {
     androidxSwipeRefreshLayoutVersion = '1.1.0'
     androidxBrowserVersion = '1.8.0'
 
-    androidxComposeBOMVersion = '2024.09.02'
+    androidxComposeBOMVersion = '2024.09.03'
     composeGooglePayButtonVersion = '1.0.0'
 
     materialVersion = '1.12.0'

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ tasks.dokkaHtmlMultiModule.configure {
 
 ext {
     minSdkVersion = 21
-    targetSdkVersion = 34
+    targetSdkVersion = 35
     compileSdkVersion = 35
 
     publishGroupId = 'com.processout'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         kotlinVersion = '2.0.20'
         kspVersion = '2.0.20-1.0.25'
         dokkaVersion = '1.9.20'
-        androidxNavigationVersion = '2.8.0'
+        androidxNavigationVersion = '2.8.1'
         nexusPublishPluginVersion = '2.0.0'
     }
     dependencies {
@@ -41,12 +41,12 @@ ext {
     androidxConstraintLayoutVersion = '2.1.4'
     androidxActivityVersion = '1.9.2'
     androidxFragmentVersion = '1.8.3'
-    androidxLifecycleVersion = '2.8.5'
+    androidxLifecycleVersion = '2.8.6'
     androidxRecyclerViewVersion = '1.3.2'
     androidxSwipeRefreshLayoutVersion = '1.1.0'
     androidxBrowserVersion = '1.8.0'
 
-    androidxComposeBOMVersion = '2024.09.01'
+    androidxComposeBOMVersion = '2024.09.02'
     composeGooglePayButtonVersion = '1.0.0'
 
     materialVersion = '1.12.0'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         kotlinVersion = '2.0.20'
         kspVersion = '2.0.20-1.0.25'
         dokkaVersion = '1.9.20'
-        androidxNavigationVersion = '2.8.1'
+        androidxNavigationVersion = '2.8.2'
         nexusPublishPluginVersion = '2.0.0'
     }
     dependencies {
@@ -40,7 +40,7 @@ ext {
     androidxAppCompatVersion = '1.7.0'
     androidxConstraintLayoutVersion = '2.1.4'
     androidxActivityVersion = '1.9.2'
-    androidxFragmentVersion = '1.8.3'
+    androidxFragmentVersion = '1.8.4'
     androidxLifecycleVersion = '2.8.6'
     androidxRecyclerViewVersion = '1.3.2'
     androidxSwipeRefreshLayoutVersion = '1.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        androidGradlePluginVersion = '8.6.0'
+        androidGradlePluginVersion = '8.7.0'
         kotlinVersion = '2.0.20'
         kspVersion = '2.0.20-1.0.25'
         dokkaVersion = '1.9.20'

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
             android:name=".ui.screen.MainActivity"
             android:exported="true"
             android:screenOrientation="portrait"
-            tools:ignore="LockedOrientationActivity">
+            tools:ignore="DiscouragedApi,LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/example/src/main/kotlin/com/processout/example/ui/screen/MainActivity.kt
+++ b/example/src/main/kotlin/com/processout/example/ui/screen/MainActivity.kt
@@ -1,6 +1,9 @@
 package com.processout.example.ui.screen
 
+import android.graphics.Color
 import android.os.Bundle
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
@@ -12,6 +15,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
         setContentView(R.layout.activity_main)
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.navigation_host_fragment) as NavHostFragment
         val navController = navHostFragment.navController

--- a/example/src/main/kotlin/com/processout/example/ui/screen/MainActivity.kt
+++ b/example/src/main/kotlin/com/processout/example/ui/screen/MainActivity.kt
@@ -1,10 +1,12 @@
 package com.processout.example.ui.screen
 
-import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
@@ -15,12 +17,36 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(
+                ContextCompat.getColor(this, com.processout.sdk.R.color.po_action_primary_default)
+            )
+        )
+        adjustInsets()
         setContentView(R.layout.activity_main)
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.navigation_host_fragment) as NavHostFragment
         val navController = navHostFragment.navController
         val appBarConfiguration = AppBarConfiguration(navController.graph)
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar)
         toolbar.setupWithNavController(navController, appBarConfiguration)
+    }
+
+    private fun adjustInsets() {
+        ViewCompat.setOnApplyWindowInsetsListener(
+            findViewById(android.R.id.content)
+        ) { content, insets ->
+            val padding = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+                        or WindowInsetsCompat.Type.displayCutout()
+                        or WindowInsetsCompat.Type.ime()
+            )
+            content.setPaddingRelative(
+                padding.left,
+                padding.top,
+                padding.right,
+                padding.bottom
+            )
+            insets
+        }
     }
 }

--- a/example/src/main/kotlin/com/processout/example/ui/screen/MainActivity.kt
+++ b/example/src/main/kotlin/com/processout/example/ui/screen/MainActivity.kt
@@ -1,12 +1,14 @@
 package com.processout.example.ui.screen
 
+import android.graphics.Color
 import android.os.Bundle
+import android.view.View
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
@@ -15,15 +17,14 @@ import com.processout.example.R
 
 class MainActivity : AppCompatActivity() {
 
+    private lateinit var topSpacer: View
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.dark(
-                ContextCompat.getColor(this, com.processout.sdk.R.color.po_action_primary_default)
-            )
-        )
-        adjustInsets()
+        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
         setContentView(R.layout.activity_main)
+        topSpacer = findViewById(R.id.top_spacer)
+        adjustInsets()
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.navigation_host_fragment) as NavHostFragment
         val navController = navHostFragment.navController
         val appBarConfiguration = AppBarConfiguration(navController.graph)
@@ -35,16 +36,18 @@ class MainActivity : AppCompatActivity() {
         ViewCompat.setOnApplyWindowInsetsListener(
             findViewById(android.R.id.content)
         ) { content, insets ->
-            val padding = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars()
-                        or WindowInsetsCompat.Type.displayCutout()
-                        or WindowInsetsCompat.Type.ime()
-            )
+            topSpacer.updateLayoutParams {
+                height = insets.getInsets(
+                    WindowInsetsCompat.Type.statusBars()
+                            or WindowInsetsCompat.Type.displayCutout()
+                ).top
+            }
             content.setPaddingRelative(
-                padding.left,
-                padding.top,
-                padding.right,
-                padding.bottom
+                0, 0, 0,
+                insets.getInsets(
+                    WindowInsetsCompat.Type.navigationBars()
+                            or WindowInsetsCompat.Type.ime()
+                ).bottom
             )
             insets
         }

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -8,13 +8,22 @@
     tools:context=".ui.screen.MainActivity"
     tools:viewBindingIgnore="true">
 
+    <View
+        android:id="@+id/top_spacer"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:background="@color/po_action_primary_default"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/top_spacer" />
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/navigation_host_fragment"

--- a/example/src/main/res/values/dimens.xml
+++ b/example/src/main/res/values/dimens.xml
@@ -3,7 +3,7 @@
     <dimen name="layout_padding">24dp</dimen>
     <dimen name="content_padding">20dp</dimen>
     <dimen name="content_marginVertical">16dp</dimen>
-    <dimen name="button_marginVertical">18dp</dimen>
+    <dimen name="button_marginVertical">16dp</dimen>
     <dimen name="button_space_vertical">8dp</dimen>
     <dimen name="input_space_vertical">12dp</dimen>
     <dimen name="subtitle_paddingVertical">8dp</dimen>

--- a/example/src/main/res/values/themes.xml
+++ b/example/src/main/res/values/themes.xml
@@ -11,6 +11,7 @@
         <item name="colorSurface">@color/po_surface_level1</item>
         <item name="android:colorBackground">@color/po_surface_level1</item>
         <item name="android:statusBarColor">@color/po_action_primary_default</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowSoftInputMode">adjustResize</item>
         <item name="toolbarStyle">@style/Widget.ProcessOut.Example.Toolbar</item>
         <item name="circularProgressIndicatorStyle">@style/Widget.Material3.CircularProgressIndicator.Small</item>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Oct 05 19:43:19 EEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodActivity.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodActivity.kt
@@ -3,6 +3,7 @@ package com.processout.sdk.ui.nativeapm
 import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 
 /**
@@ -13,6 +14,8 @@ class PONativeAlternativePaymentMethodActivity : AppCompatActivity(), BottomShee
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
         // This is a workaround for crash on Android 8.0 (API level 26).
         // https://issuetracker.google.com/issues/68454482
         // https://stackoverflow.com/questions/48072438/java-lang-illegalstateexception-only-fullscreen-opaque-activities-can-request-o

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodBottomSheet.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/nativeapm/PONativeAlternativePaymentMethodBottomSheet.kt
@@ -96,7 +96,7 @@ class PONativeAlternativePaymentMethodBottomSheet : BottomSheetDialogFragment() 
     private val screenHeight by lazy { requireContext().screenSize().height }
 
     private var minPeekHeight: Int = 0
-    private val maxPeekHeight by lazy { (screenHeight * 0.75).roundToInt() }
+    private val maxPeekHeight by lazy { (screenHeight * 0.8).roundToInt() }
     private val defaultPeekHeight by lazy { resources.getDimensionPixelSize(R.dimen.po_bottomSheet_minHeight) }
 
     private val handler by lazy { Handler(Looper.getMainLooper()) }

--- a/sdk/src/main/res/values-v21/themes.xml
+++ b/sdk/src/main/res/values-v21/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="ThemeOverlay.ProcessOut.BottomSheetDialog" parent="ThemeOverlay.ProcessOut.Base.BottomSheetDialog">
+        <item name="android:windowTranslucentNavigation">true</item>
+    </style>
+
+</resources>

--- a/sdk/src/main/res/values-v29/themes.xml
+++ b/sdk/src/main/res/values-v29/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="ThemeOverlay.ProcessOut.BottomSheetDialog" parent="ThemeOverlay.ProcessOut.Base.BottomSheetDialog">
+        <item name="android:windowTranslucentNavigation">false</item>
+    </style>
+
+</resources>

--- a/sdk/src/main/res/values/dimens.xml
+++ b/sdk/src/main/res/values/dimens.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="po_bottomSheet_minHeight">438dp</dimen>
+    <dimen name="po_bottomSheet_minHeight">440dp</dimen>
     <dimen name="po_bottomSheet_margin">24dp</dimen>
     <dimen name="po_bottomSheet_content_padding">16dp</dimen>
     <dimen name="po_bottomSheet_scrollableContent_paddingVertical">28dp</dimen>

--- a/sdk/src/main/res/values/styles.xml
+++ b/sdk/src/main/res/values/styles.xml
@@ -4,6 +4,8 @@
     <style name="Widget.ProcessOut.BottomSheet.Modal" parent="Widget.Material3.BottomSheet.Modal">
         <item name="android:elevation">0dp</item>
         <item name="backgroundTint">@android:color/transparent</item>
+        <item name="paddingTopSystemWindowInsets">false</item>
+        <item name="paddingBottomSystemWindowInsets">false</item>
     </style>
 
     <style name="Widget.ProcessOut.Title" parent="Widget.MaterialComponents.TextView">

--- a/sdk/src/main/res/values/themes.xml
+++ b/sdk/src/main/res/values/themes.xml
@@ -37,9 +37,10 @@
         <item name="poCodeEditTextStyle">@style/Widget.ProcessOut.CodeEditText</item>
     </style>
 
-    <style name="ThemeOverlay.ProcessOut.BottomSheetDialog" parent="ThemeOverlay.Material3.BottomSheetDialog">
+    <style name="ThemeOverlay.ProcessOut.Base.BottomSheetDialog" parent="ThemeOverlay.Material3.BottomSheetDialog">
         <item name="android:backgroundDimEnabled">true</item>
         <item name="android:windowSoftInputMode">adjustResize</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="colorSurface">@android:color/transparent</item>
         <item name="bottomSheetStyle">@style/Widget.ProcessOut.BottomSheet.Modal</item>
     </style>

--- a/sdk/src/main/res/values/themes.xml
+++ b/sdk/src/main/res/values/themes.xml
@@ -5,6 +5,7 @@
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowIsFloating">false</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:colorBackgroundCacheHint">@null</item>
         <item name="android:backgroundDimEnabled">false</item>
@@ -40,7 +41,6 @@
     <style name="ThemeOverlay.ProcessOut.Base.BottomSheetDialog" parent="ThemeOverlay.Material3.BottomSheetDialog">
         <item name="android:backgroundDimEnabled">true</item>
         <item name="android:windowSoftInputMode">adjustResize</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="colorSurface">@android:color/transparent</item>
         <item name="bottomSheetStyle">@style/Widget.ProcessOut.BottomSheet.Modal</item>
     </style>

--- a/sdk/src/testProductionDebug/kotlin/com/processout/sdk/AlternativePaymentMethodsServiceTests.kt
+++ b/sdk/src/testProductionDebug/kotlin/com/processout/sdk/AlternativePaymentMethodsServiceTests.kt
@@ -1,6 +1,7 @@
 package com.processout.sdk
 
 import android.net.Uri
+import android.os.Build
 import com.processout.sdk.api.ProcessOut
 import com.processout.sdk.api.model.request.POAlternativePaymentMethodRequest
 import com.processout.sdk.api.model.response.POAlternativePaymentMethodResponse
@@ -18,7 +19,10 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@Config(
+    sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE],
+    application = TestApplication::class
+)
 class AlternativePaymentMethodsServiceTests {
 
     @Rule

--- a/sdk/src/testProductionDebug/kotlin/com/processout/sdk/CardsRepositoryTests.kt
+++ b/sdk/src/testProductionDebug/kotlin/com/processout/sdk/CardsRepositoryTests.kt
@@ -1,5 +1,6 @@
 package com.processout.sdk
 
+import android.os.Build
 import com.processout.sdk.api.ProcessOut
 import com.processout.sdk.api.model.request.POCardTokenizationRequest
 import com.processout.sdk.api.model.request.POCardUpdateCVCRequest
@@ -18,7 +19,10 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@Config(
+    sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE],
+    application = TestApplication::class
+)
 class CardsRepositoryTests {
 
     @Rule

--- a/sdk/src/testProductionDebug/kotlin/com/processout/sdk/CustomerTokensRepositoryTests.kt
+++ b/sdk/src/testProductionDebug/kotlin/com/processout/sdk/CustomerTokensRepositoryTests.kt
@@ -1,5 +1,6 @@
 package com.processout.sdk
 
+import android.os.Build
 import com.processout.sdk.api.ProcessOut
 import com.processout.sdk.api.model.request.*
 import com.processout.sdk.api.repository.CustomerTokensRepository
@@ -18,7 +19,10 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@Config(
+    sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE],
+    application = TestApplication::class
+)
 class CustomerTokensRepositoryTests {
 
     @Rule

--- a/sdk/src/testProductionDebug/kotlin/com/processout/sdk/GatewayConfigurationsRepositoryTests.kt
+++ b/sdk/src/testProductionDebug/kotlin/com/processout/sdk/GatewayConfigurationsRepositoryTests.kt
@@ -1,5 +1,6 @@
 package com.processout.sdk
 
+import android.os.Build
 import com.processout.sdk.api.ProcessOut
 import com.processout.sdk.api.model.request.POAllGatewayConfigurationsRequest
 import com.processout.sdk.api.model.request.POGatewayConfigurationRequest
@@ -17,7 +18,10 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@Config(
+    sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE],
+    application = TestApplication::class
+)
 class GatewayConfigurationsRepositoryTests {
 
     @Rule

--- a/sdk/src/testProductionDebug/kotlin/com/processout/sdk/InvoicesRepositoryTests.kt
+++ b/sdk/src/testProductionDebug/kotlin/com/processout/sdk/InvoicesRepositoryTests.kt
@@ -1,5 +1,6 @@
 package com.processout.sdk
 
+import android.os.Build
 import com.processout.sdk.api.ProcessOut
 import com.processout.sdk.api.model.request.*
 import com.processout.sdk.api.model.response.CustomerAction
@@ -22,7 +23,10 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@Config(
+    sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE],
+    application = TestApplication::class
+)
 class InvoicesRepositoryTests {
 
     @Rule

--- a/ui/src/main/kotlin/com/processout/sdk/ui/base/BaseBottomSheetDialogFragment.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/base/BaseBottomSheetDialogFragment.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.activity.addCallback
+import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
@@ -57,9 +58,23 @@ internal abstract class BaseBottomSheetDialogFragment<T : Parcelable> : BottomSh
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        adjustInsets()
         apply(Window(height = defaultViewHeight, availableHeight = screenHeight))
         apply(cancellationConfiguration)
         dispatchBackPressed()
+    }
+
+    private fun adjustInsets() {
+        val container: FrameLayout = requireDialog().findViewById(
+            com.google.android.material.R.id.container
+        )
+        ViewCompat.setOnApplyWindowInsetsListener(container) { _, insets ->
+            val statusBarInsets = insets.getInsets(WindowInsetsCompat.Type.statusBars())
+            view?.setPaddingRelative(0, statusBarInsets.top, 0, 0)
+            WindowInsetsCompat.Builder(insets)
+                .setInsets(WindowInsetsCompat.Type.statusBars(), Insets.of(0, 0, 0, 0))
+                .build()
+        }
     }
 
     protected fun apply(screenMode: ScreenMode, animate: Boolean = false) {
@@ -131,14 +146,7 @@ internal abstract class BaseBottomSheetDialogFragment<T : Parcelable> : BottomSh
                         WindowInsetsCompat.Type.navigationBars()
                     )?.bottom ?: 0
 
-                    var imeHeight = windowInsets?.getInsets(
-                        WindowInsetsCompat.Type.ime()
-                    )?.bottom ?: 0
-                    if (imeHeight != 0) {
-                        imeHeight -= navigationBarHeight
-                    }
-
-                    var updatedHeight = screenHeight - imeHeight - viewCoordinateY
+                    var updatedHeight = screenHeight + navigationBarHeight - viewCoordinateY
                     if (updatedHeight < bottomSheetBehavior.peekHeight) {
                         updatedHeight = bottomSheetBehavior.peekHeight
                     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/base/BaseBottomSheetDialogFragment.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/base/BaseBottomSheetDialogFragment.kt
@@ -154,11 +154,8 @@ internal abstract class BaseBottomSheetDialogFragment<T : Parcelable> : BottomSh
                         )?.top ?: 0
                         updatedHeight += displayCutoutHeight
                     }
-                    if (updatedHeight < bottomSheetBehavior.peekHeight) {
-                        updatedHeight = bottomSheetBehavior.peekHeight
-                    }
                     updateLayoutParams {
-                        height = updatedHeight
+                        height = updatedHeight.coerceAtLeast(bottomSheetBehavior.peekHeight)
                     }
                 }
             }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/base/BaseBottomSheetDialogFragment.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/base/BaseBottomSheetDialogFragment.kt
@@ -5,6 +5,7 @@ package com.processout.sdk.ui.base
 import android.animation.ValueAnimator
 import android.content.DialogInterface
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
@@ -147,6 +148,12 @@ internal abstract class BaseBottomSheetDialogFragment<T : Parcelable> : BottomSh
                     )?.bottom ?: 0
 
                     var updatedHeight = screenHeight + navigationBarHeight - viewCoordinateY
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                        val displayCutoutHeight = windowInsets?.getInsets(
+                            WindowInsetsCompat.Type.displayCutout()
+                        )?.top ?: 0
+                        updatedHeight += displayCutoutHeight
+                    }
                     if (updatedHeight < bottomSheetBehavior.peekHeight) {
                         updatedHeight = bottomSheetBehavior.peekHeight
                     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationActivity.kt
@@ -1,12 +1,14 @@
 package com.processout.sdk.ui.card.tokenization
 
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import com.processout.sdk.ui.base.BaseTransparentPortraitActivity
 
 internal class CardTokenizationActivity : BaseTransparentPortraitActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         if (savedInstanceState == null) {
             val bottomSheet = supportFragmentManager.findFragmentByTag(CardTokenizationBottomSheet.tag)
             if (bottomSheet == null) {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationBottomSheet.kt
@@ -24,6 +24,7 @@ import com.processout.sdk.ui.card.tokenization.CardTokenizationCompletion.Failur
 import com.processout.sdk.ui.card.tokenization.CardTokenizationCompletion.Success
 import com.processout.sdk.ui.card.tokenization.CardTokenizationEvent.Dismiss
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
+import com.processout.sdk.ui.shared.component.displayCutoutHeight
 import com.processout.sdk.ui.shared.component.screenModeAsState
 
 internal class CardTokenizationBottomSheet : BaseBottomSheetDialogFragment<POCard>() {
@@ -64,7 +65,7 @@ internal class CardTokenizationBottomSheet : BaseBottomSheetDialogFragment<POCar
                     LaunchedEffect(value) { handle(value) }
                 }
 
-                with(screenModeAsState(viewHeight = defaultViewHeight)) {
+                with(screenModeAsState(viewHeight = defaultViewHeight + displayCutoutHeight())) {
                     LaunchedEffect(value) { apply(value) }
                 }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationScreen.kt
@@ -34,6 +34,7 @@ import com.processout.sdk.ui.core.state.POActionState
 import com.processout.sdk.ui.core.state.POImmutableList
 import com.processout.sdk.ui.core.style.POAxis
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
+import com.processout.sdk.ui.shared.component.DynamicFooter
 import com.processout.sdk.ui.shared.component.rememberLifecycleEvent
 import com.processout.sdk.ui.shared.state.FieldState
 
@@ -59,12 +60,14 @@ internal fun CardTokenizationScreen(
             )
         },
         bottomBar = {
-            Actions(
-                primary = state.primaryAction,
-                secondary = state.secondaryAction,
-                onEvent = onEvent,
-                style = style.actionsContainer
-            )
+            DynamicFooter {
+                Actions(
+                    primary = state.primaryAction,
+                    secondary = state.secondaryAction,
+                    onEvent = onEvent,
+                    style = style.actionsContainer
+                )
+            }
         }
     ) { scaffoldPadding ->
         Column(

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateActivity.kt
@@ -1,12 +1,14 @@
 package com.processout.sdk.ui.card.update
 
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import com.processout.sdk.ui.base.BaseTransparentPortraitActivity
 
 internal class CardUpdateActivity : BaseTransparentPortraitActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         if (savedInstanceState == null) {
             val bottomSheet = supportFragmentManager.findFragmentByTag(CardUpdateBottomSheet.tag)
             if (bottomSheet == null) {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateBottomSheet.kt
@@ -32,7 +32,7 @@ internal class CardUpdateBottomSheet : BaseBottomSheetDialogFragment<POCard>() {
     }
 
     override val expandable = false
-    override val defaultViewHeight by lazy { 420.dpToPx(requireContext()) }
+    override val defaultViewHeight by lazy { 440.dpToPx(requireContext()) }
 
     private var configuration: POCardUpdateConfiguration? = null
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateScreen.kt
@@ -27,6 +27,7 @@ import com.processout.sdk.ui.core.state.POActionState
 import com.processout.sdk.ui.core.state.POImmutableList
 import com.processout.sdk.ui.core.style.POAxis
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
+import com.processout.sdk.ui.shared.component.DynamicFooter
 import com.processout.sdk.ui.shared.component.rememberLifecycleEvent
 import com.processout.sdk.ui.shared.state.FieldState
 
@@ -52,12 +53,14 @@ internal fun CardUpdateScreen(
             )
         },
         bottomBar = {
-            Actions(
-                primary = state.primaryAction,
-                secondary = state.secondaryAction,
-                onEvent = onEvent,
-                style = style.actionsContainer
-            )
+            DynamicFooter {
+                Actions(
+                    primary = state.primaryAction,
+                    secondary = state.secondaryAction,
+                    onEvent = onEvent,
+                    style = style.actionsContainer
+                )
+            }
         }
     ) { scaffoldPadding ->
         Column(

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
@@ -133,10 +133,7 @@ internal class DynamicCheckoutActivity : BaseTransparentPortraitActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
-            navigationBarStyle = SystemBarStyle.dark(Color.BLACK)
-        )
+        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
         if (savedInstanceState == null) {
             initConfiguration()
         }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/DynamicCheckoutScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/DynamicCheckoutScreen.kt
@@ -60,9 +60,9 @@ import com.processout.sdk.ui.core.theme.ProcessOutTheme.colors
 import com.processout.sdk.ui.core.theme.ProcessOutTheme.shapes
 import com.processout.sdk.ui.core.theme.ProcessOutTheme.spacing
 import com.processout.sdk.ui.core.theme.ProcessOutTheme.typography
+import com.processout.sdk.ui.shared.component.DynamicFooter
 import com.processout.sdk.ui.shared.component.GooglePayButton
 import com.processout.sdk.ui.shared.component.TextAndroidView
-import com.processout.sdk.ui.shared.component.isImeVisibleAsState
 import com.processout.sdk.ui.shared.extension.*
 
 @Composable
@@ -80,12 +80,14 @@ internal fun DynamicCheckoutScreen(
                 .clip(shape = shapes.topRoundedCornersLarge),
             containerColor = style.backgroundColor,
             bottomBar = {
-                Footer(
-                    state = state,
-                    onEvent = onEvent,
-                    containerStyle = style.actionsContainer,
-                    dialogStyle = style.dialog
-                )
+                DynamicFooter {
+                    Actions(
+                        state = state,
+                        onEvent = onEvent,
+                        containerStyle = style.actionsContainer,
+                        dialogStyle = style.dialog
+                    )
+                }
             }
         ) { scaffoldPadding ->
             Column(
@@ -443,44 +445,32 @@ private fun PaymentLogo(
 }
 
 @Composable
-private fun Footer(
+private fun Actions(
     state: DynamicCheckoutViewModelState,
     onEvent: (DynamicCheckoutEvent) -> Unit,
     containerStyle: POActionsContainer.Style,
     dialogStyle: PODialog.Style
 ) {
-    Column {
-        var cancelAction: POActionState? = null
-        when (state) {
-            is Starting -> cancelAction = state.cancelAction
-            is Started -> cancelAction = state.cancelAction
-            else -> {}
-        }
-        if (cancelAction != null) {
-            POActionsContainer(
-                actions = POImmutableList(listOf(cancelAction)),
-                onClick = {
-                    onEvent(
-                        Action(
-                            actionId = it,
-                            paymentMethodId = null
-                        )
+    var cancelAction: POActionState? = null
+    when (state) {
+        is Starting -> cancelAction = state.cancelAction
+        is Started -> cancelAction = state.cancelAction
+        else -> {}
+    }
+    if (cancelAction != null) {
+        POActionsContainer(
+            actions = POImmutableList(listOf(cancelAction)),
+            onClick = {
+                onEvent(
+                    Action(
+                        actionId = it,
+                        paymentMethodId = null
                     )
-                },
-                onConfirmationRequested = { onEvent(ActionConfirmationRequested(id = it)) },
-                containerStyle = containerStyle,
-                dialogStyle = dialogStyle
-            )
-        }
-
-        val isImeVisible by isImeVisibleAsState()
-        val imePaddingValues = WindowInsets.ime.asPaddingValues()
-        val systemBarsPaddingValues = WindowInsets.systemBars.asPaddingValues()
-        Spacer(
-            Modifier.requiredHeight(
-                if (isImeVisible) imePaddingValues.calculateBottomPadding()
-                else systemBarsPaddingValues.calculateBottomPadding()
-            )
+                )
+            },
+            onConfirmationRequested = { onEvent(ActionConfirmationRequested(id = it)) },
+            containerStyle = containerStyle,
+            dialogStyle = dialogStyle
         )
     }
 }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/DynamicCheckoutScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/DynamicCheckoutScreen.kt
@@ -73,10 +73,10 @@ internal fun DynamicCheckoutScreen(
     isLightTheme: Boolean
 ) {
     Column {
-        Spacer(Modifier.windowInsetsTopHeight(WindowInsets.statusBars))
+        Spacer(Modifier.windowInsetsTopHeight(WindowInsets.safeDrawing))
         Scaffold(
             modifier = Modifier
-                .consumeWindowInsets(WindowInsets.statusBars)
+                .consumeWindowInsets(WindowInsets.safeDrawing)
                 .clip(shape = shapes.topRoundedCornersLarge),
             containerColor = style.backgroundColor,
             bottomBar = {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentActivity.kt
@@ -1,12 +1,14 @@
 package com.processout.sdk.ui.napm
 
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import com.processout.sdk.ui.base.BaseTransparentPortraitActivity
 
 internal class NativeAlternativePaymentActivity : BaseTransparentPortraitActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         if (savedInstanceState == null) {
             val bottomSheet = supportFragmentManager.findFragmentByTag(NativeAlternativePaymentBottomSheet.tag)
             if (bottomSheet == null) {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentBottomSheet.kt
@@ -38,7 +38,7 @@ internal class NativeAlternativePaymentBottomSheet : BaseBottomSheetDialogFragme
 
     override val expandable = true
     override val defaultViewHeight by lazy { 460.dpToPx(requireContext()) }
-    private val maxPeekHeight by lazy { (screenHeight * 0.75).roundToInt() }
+    private val maxPeekHeight by lazy { (screenHeight * 0.8).roundToInt() }
 
     private var configuration: PONativeAlternativePaymentConfiguration? = null
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentBottomSheet.kt
@@ -37,7 +37,7 @@ internal class NativeAlternativePaymentBottomSheet : BaseBottomSheetDialogFragme
     }
 
     override val expandable = true
-    override val defaultViewHeight by lazy { 440.dpToPx(requireContext()) }
+    override val defaultViewHeight by lazy { 460.dpToPx(requireContext()) }
     private val maxPeekHeight by lazy { (screenHeight * 0.75).roundToInt() }
 
     private var configuration: PONativeAlternativePaymentConfiguration? = null

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentScreen.kt
@@ -57,6 +57,7 @@ import com.processout.sdk.ui.napm.NativeAlternativePaymentScreen.codeFieldHorizo
 import com.processout.sdk.ui.napm.NativeAlternativePaymentScreen.messageGravity
 import com.processout.sdk.ui.napm.NativeAlternativePaymentViewModelState.*
 import com.processout.sdk.ui.napm.NativeAlternativePaymentViewModelState.Field.*
+import com.processout.sdk.ui.shared.component.DynamicFooter
 import com.processout.sdk.ui.shared.component.TextAndroidView
 import com.processout.sdk.ui.shared.component.rememberLifecycleEvent
 import com.processout.sdk.ui.shared.extension.dpToPx
@@ -95,15 +96,17 @@ internal fun NativeAlternativePaymentScreen(
             )
         },
         bottomBar = {
-            Actions(
-                modifier = Modifier.onGloballyPositioned {
-                    bottomBarHeight = it.size.height
-                },
-                state = state,
-                onEvent = onEvent,
-                containerStyle = style.actionsContainer,
-                dialogStyle = style.dialog
-            )
+            DynamicFooter {
+                Actions(
+                    modifier = Modifier.onGloballyPositioned {
+                        bottomBarHeight = it.size.height
+                    },
+                    state = state,
+                    onEvent = onEvent,
+                    containerStyle = style.actionsContainer,
+                    dialogStyle = style.dialog
+                )
+            }
         }
     ) { scaffoldPadding ->
         val verticalSpacing = ProcessOutTheme.spacing.extraLarge

--- a/ui/src/main/kotlin/com/processout/sdk/ui/shared/component/DynamicFooter.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/shared/component/DynamicFooter.kt
@@ -1,0 +1,32 @@
+package com.processout.sdk.ui.shared.component
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+internal fun DynamicFooter(
+    modifier: Modifier = Modifier,
+    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = verticalArrangement,
+        horizontalAlignment = horizontalAlignment
+    ) {
+        content()
+        val isImeVisible by isImeVisibleAsState()
+        val imePaddingValues = WindowInsets.ime.asPaddingValues()
+        val navigationBarPaddingValues = WindowInsets.navigationBars.asPaddingValues()
+        Spacer(
+            Modifier.requiredHeight(
+                if (isImeVisible) imePaddingValues.calculateBottomPadding()
+                else navigationBarPaddingValues.calculateBottomPadding()
+            )
+        )
+    }
+}

--- a/ui/src/main/kotlin/com/processout/sdk/ui/shared/component/Screen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/shared/component/Screen.kt
@@ -1,17 +1,13 @@
 package com.processout.sdk.ui.shared.component
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.unit.dp
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.processout.sdk.ui.shared.component.ScreenMode.Fullscreen
 import com.processout.sdk.ui.shared.component.ScreenMode.Window
-import com.processout.sdk.ui.shared.extension.dpToPx
+import com.processout.sdk.ui.shared.extension.screenSize
 
 internal sealed interface ScreenMode {
     data class Window(val height: Int, val availableHeight: Int) : ScreenMode
@@ -20,16 +16,14 @@ internal sealed interface ScreenMode {
 
 @Composable
 internal fun screenModeAsState(viewHeight: Int): State<ScreenMode> {
-    val isImeVisible = isImeVisibleAsState().value
-    val screenHeight = LocalConfiguration.current.screenHeightDp.dp.dpToPx()
-    val availableHeight = if (isImeVisible) screenHeight - imeHeight() + navigationBarHeight() else screenHeight
-    val screenMode = remember {
-        mutableStateOf<ScreenMode>(Window(height = viewHeight, availableHeight = availableHeight))
+    val isImeVisible by isImeVisibleAsState()
+    val totalViewHeight = if (isImeVisible) viewHeight + imeHeight() else viewHeight
+    val screenHeight = LocalContext.current.screenSize().height + navigationBarHeight()
+    val screenMode = remember(totalViewHeight, screenHeight) {
+        mutableStateOf<ScreenMode>(Window(height = totalViewHeight, availableHeight = screenHeight))
     }
-    if (availableHeight < viewHeight) {
+    if (screenHeight < totalViewHeight) {
         screenMode.value = Fullscreen(screenHeight)
-    } else {
-        screenMode.value = Window(height = viewHeight, availableHeight = availableHeight)
     }
     return screenMode
 }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/shared/component/Screen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/shared/component/Screen.kt
@@ -17,7 +17,9 @@ internal sealed interface ScreenMode {
 @Composable
 internal fun screenModeAsState(viewHeight: Int): State<ScreenMode> {
     val isImeVisible by isImeVisibleAsState()
-    val totalViewHeight = if (isImeVisible) viewHeight + imeHeight() else viewHeight
+    val totalViewHeight = if (isImeVisible)
+        viewHeight + imeHeight() else
+        viewHeight + navigationBarHeight()
     val screenHeight = LocalContext.current.screenSize().height + navigationBarHeight()
     val screenMode = remember(totalViewHeight, screenHeight) {
         mutableStateOf<ScreenMode>(Window(height = totalViewHeight, availableHeight = screenHeight))

--- a/ui/src/main/kotlin/com/processout/sdk/ui/shared/component/Screen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/shared/component/Screen.kt
@@ -28,7 +28,7 @@ internal fun screenModeAsState(viewHeight: Int): State<ScreenMode> {
     val screenMode = remember(totalViewHeight, screenHeight) {
         mutableStateOf<ScreenMode>(Window(height = totalViewHeight, availableHeight = screenHeight))
     }
-    if (screenHeight < totalViewHeight) {
+    if (screenHeight <= totalViewHeight) {
         screenMode.value = Fullscreen(screenHeight)
     }
     return screenMode

--- a/ui/src/main/kotlin/com/processout/sdk/ui/shared/component/Screen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/shared/component/Screen.kt
@@ -1,5 +1,6 @@
 package com.processout.sdk.ui.shared.component
 
+import android.os.Build
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -20,7 +21,10 @@ internal fun screenModeAsState(viewHeight: Int): State<ScreenMode> {
     val totalViewHeight = if (isImeVisible)
         viewHeight + imeHeight() else
         viewHeight + navigationBarHeight()
-    val screenHeight = LocalContext.current.screenSize().height + navigationBarHeight()
+    var screenHeight = LocalContext.current.screenSize().height + navigationBarHeight()
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+        screenHeight += displayCutoutHeight()
+    }
     val screenMode = remember(totalViewHeight, screenHeight) {
         mutableStateOf<ScreenMode>(Window(height = totalViewHeight, availableHeight = screenHeight))
     }
@@ -29,6 +33,12 @@ internal fun screenModeAsState(viewHeight: Int): State<ScreenMode> {
     }
     return screenMode
 }
+
+@Composable
+internal fun displayCutoutHeight(): Int =
+    ViewCompat.getRootWindowInsets(LocalView.current.rootView)
+        ?.getInsets(WindowInsetsCompat.Type.displayCutout())
+        ?.top ?: 0
 
 @Composable
 internal fun navigationBarHeight(): Int =


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Supports `targetSdkVersion = 35` enforced edge-to-edge with backwards compatibility.
Includes display cutout insets (e.g. camera).
Applies to all screens and supported API levels.

**API 35**
<img width=200 src=https://github.com/user-attachments/assets/328a3343-24bb-4bd2-9a1a-07af2e57e347/>
<img width=200 src=https://github.com/user-attachments/assets/ddef86dc-3c44-4d52-a8f4-4620ccd82dfe/>
<img width=200 src=https://github.com/user-attachments/assets/5f73c1dd-6a04-42da-a1bf-f302d0103152/>
<img width=200 src=https://github.com/user-attachments/assets/de5224a6-53c8-4cb7-9b09-c8798d26a594/>

**API 33**
<img width=200 src=https://github.com/user-attachments/assets/0396d478-555a-452e-8992-b0ab1e61773d/>
<img width=200 src=https://github.com/user-attachments/assets/086953cc-14db-422b-a593-dc7a945bae6d/>

**API 28**
<img width=200 src=https://github.com/user-attachments/assets/0c671220-c06e-4994-ac36-0edbe70997ac/>
<img width=200 src=https://github.com/user-attachments/assets/0aa4da4d-b64d-44fa-a4e3-a7b026dc6fbe/>
<img width=200 src=https://github.com/user-attachments/assets/d8f8218f-f91f-4971-93b4-312bd666609c/>
<img width=200 src=https://github.com/user-attachments/assets/06061be0-5fe4-485f-a427-389b5c09aa96/>

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-424
