### PR TITLE
feat(POM-419): Dynamic Checkout lifecycle events

### DIFF
--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PODynamicCheckoutEvent.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PODynamicCheckoutEvent.kt
@@ -32,7 +32,8 @@ sealed class PODynamicCheckoutEvent {
     ) : PODynamicCheckoutEvent()
 
     /**
-     * Event is sent when payment method selection has failed.
+     * Event is sent when certain payment method has failed with retryable error.
+     * User can provide different payment details or try another payment method.
      */
     data class DidFailPayment(
         val failure: ProcessOutResult.Failure,

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PODynamicCheckoutEvent.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PODynamicCheckoutEvent.kt
@@ -20,13 +20,6 @@ sealed class PODynamicCheckoutEvent {
     data object DidStart : PODynamicCheckoutEvent()
 
     /**
-     * Event is sent when user attempts to select payment method.
-     */
-    data class WillSelectPaymentMethod(
-        val paymentMethod: PODynamicCheckoutPaymentMethod
-    ) : PODynamicCheckoutEvent()
-
-    /**
      * Event is sent when payment method is selected by the user.
      */
     data class DidSelectPaymentMethod(

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PODynamicCheckoutEvent.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PODynamicCheckoutEvent.kt
@@ -1,0 +1,57 @@
+package com.processout.sdk.api.model.event
+
+import com.processout.sdk.api.model.response.PODynamicCheckoutPaymentMethod
+import com.processout.sdk.core.ProcessOutResult
+
+/**
+ * Defines dynamic checkout lifecycle events.
+ */
+sealed class PODynamicCheckoutEvent {
+
+    /**
+     * Initial event that is sent prior any other event.
+     */
+    data object WillStart : PODynamicCheckoutEvent()
+
+    /**
+     * Event indicates that initialization is complete.
+     * Currently waiting for user input.
+     */
+    data object DidStart : PODynamicCheckoutEvent()
+
+    /**
+     * Event is sent when user attempts to select payment method.
+     */
+    data class WillSelectPaymentMethod(
+        val paymentMethod: PODynamicCheckoutPaymentMethod
+    ) : PODynamicCheckoutEvent()
+
+    /**
+     * Event is sent when payment method is selected by the user.
+     */
+    data class DidSelectPaymentMethod(
+        val paymentMethod: PODynamicCheckoutPaymentMethod
+    ) : PODynamicCheckoutEvent()
+
+    /**
+     * Event is sent when payment method selection has failed.
+     */
+    data class DidFailToSelectPaymentMethod(
+        val failure: ProcessOutResult.Failure,
+        val paymentMethod: PODynamicCheckoutPaymentMethod
+    ) : PODynamicCheckoutEvent()
+
+    /**
+     * Event is sent after payment was confirmed to be captured. This is a final event.
+     */
+    data class DidCompletePayment(
+        val paymentMethod: PODynamicCheckoutPaymentMethod
+    ) : PODynamicCheckoutEvent()
+
+    /**
+     * Event is sent when unretryable error occurs. This is a final event.
+     */
+    data class DidFail(
+        val failure: ProcessOutResult.Failure
+    ) : PODynamicCheckoutEvent()
+}

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PODynamicCheckoutEvent.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PODynamicCheckoutEvent.kt
@@ -20,6 +20,11 @@ sealed class PODynamicCheckoutEvent {
     data object DidStart : PODynamicCheckoutEvent()
 
     /**
+     * Event is sent when user asked to confirm cancellation, e.g. via dialog.
+     */
+    data object DidRequestCancelConfirmation : PODynamicCheckoutEvent()
+
+    /**
      * Event is sent when payment method is selected by the user.
      */
     data class DidSelectPaymentMethod(
@@ -29,15 +34,10 @@ sealed class PODynamicCheckoutEvent {
     /**
      * Event is sent when payment method selection has failed.
      */
-    data class DidFailToSelectPaymentMethod(
+    data class DidFailPayment(
         val failure: ProcessOutResult.Failure,
         val paymentMethod: PODynamicCheckoutPaymentMethod
     ) : PODynamicCheckoutEvent()
-
-    /**
-     * Event is sent when user asked to confirm cancellation, e.g. via dialog.
-     */
-    data object DidRequestCancelConfirmation : PODynamicCheckoutEvent()
 
     /**
      * Event is sent after payment was confirmed to be captured. This is a final event.

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PODynamicCheckoutEvent.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PODynamicCheckoutEvent.kt
@@ -42,6 +42,11 @@ sealed class PODynamicCheckoutEvent {
     ) : PODynamicCheckoutEvent()
 
     /**
+     * Event is sent when user asked to confirm cancellation, e.g. via dialog.
+     */
+    data object DidRequestCancelConfirmation : PODynamicCheckoutEvent()
+
+    /**
      * Event is sent after payment was confirmed to be captured. This is a final event.
      */
     data class DidCompletePayment(

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/request/POCardTokenizationPreferredSchemeRequest.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/request/POCardTokenizationPreferredSchemeRequest.kt
@@ -1,5 +1,6 @@
 package com.processout.sdk.api.model.request
 
+import com.processout.sdk.api.dispatcher.POEventDispatcher
 import com.processout.sdk.api.model.response.POCardIssuerInformation
 import com.processout.sdk.core.annotation.ProcessOutInternalApi
 import java.util.UUID
@@ -12,5 +13,5 @@ import java.util.UUID
  */
 data class POCardTokenizationPreferredSchemeRequest @ProcessOutInternalApi constructor(
     val issuerInformation: POCardIssuerInformation,
-    val uuid: UUID = UUID.randomUUID()
-)
+    override val uuid: UUID = UUID.randomUUID()
+) : POEventDispatcher.Request

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/request/PONativeAlternativePaymentMethodDefaultValuesRequest.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/request/PONativeAlternativePaymentMethodDefaultValuesRequest.kt
@@ -1,5 +1,6 @@
 package com.processout.sdk.api.model.request
 
+import com.processout.sdk.api.dispatcher.POEventDispatcher
 import com.processout.sdk.api.model.response.PONativeAlternativePaymentMethodParameter
 import com.processout.sdk.core.annotation.ProcessOutInternalApi
 import java.util.UUID
@@ -16,5 +17,5 @@ data class PONativeAlternativePaymentMethodDefaultValuesRequest @ProcessOutInter
     val gatewayConfigurationId: String,
     val invoiceId: String,
     val parameters: List<PONativeAlternativePaymentMethodParameter>,
-    val uuid: UUID = UUID.randomUUID()
-)
+    override val uuid: UUID = UUID.randomUUID()
+) : POEventDispatcher.Request

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/response/InvoiceResponse.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/response/InvoiceResponse.kt
@@ -140,7 +140,8 @@ sealed class PODynamicCheckoutPaymentMethod {
         val name: String,
         val logo: POImageResource,
         @Json(name = "brand_color")
-        val brandColor: POColor
+        val brandColor: POColor,
+        val description: String?
     )
 
     /**

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/response/POCardTokenizationPreferredSchemeResponse.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/response/POCardTokenizationPreferredSchemeResponse.kt
@@ -1,5 +1,6 @@
 package com.processout.sdk.api.model.response
 
+import com.processout.sdk.api.dispatcher.POEventDispatcher
 import com.processout.sdk.api.model.request.POCardTokenizationPreferredSchemeRequest
 import java.util.UUID
 
@@ -12,10 +13,10 @@ import java.util.UUID
  * @param[preferredScheme] Preferred scheme that will be used by default for card tokenization.
  */
 data class POCardTokenizationPreferredSchemeResponse internal constructor(
-    val uuid: UUID,
+    override val uuid: UUID,
     val issuerInformation: POCardIssuerInformation,
     val preferredScheme: String?
-)
+) : POEventDispatcher.Response
 
 /**
  * Creates [POCardTokenizationPreferredSchemeResponse] from [POCardTokenizationPreferredSchemeRequest].

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/response/PONativeAlternativePaymentMethodDefaultValuesResponse.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/response/PONativeAlternativePaymentMethodDefaultValuesResponse.kt
@@ -1,5 +1,6 @@
 package com.processout.sdk.api.model.response
 
+import com.processout.sdk.api.dispatcher.POEventDispatcher
 import com.processout.sdk.api.model.request.PONativeAlternativePaymentMethodDefaultValuesRequest
 import java.util.UUID
 
@@ -11,9 +12,9 @@ import java.util.UUID
  * @param[defaultValues] Map where key is [PONativeAlternativePaymentMethodParameter.key] and value is a default value for this parameter.
  */
 data class PONativeAlternativePaymentMethodDefaultValuesResponse internal constructor(
-    val uuid: UUID,
+    override val uuid: UUID,
     val defaultValues: Map<String, String>
-)
+) : POEventDispatcher.Response
 
 /**
  * Creates response with default values from request to use the same UUID.

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -429,20 +429,15 @@ internal class DynamicCheckoutInteractor(
         if (event.id == _state.value.selectedPaymentMethod?.id) {
             return
         }
-        val originalPaymentMethod = paymentMethod(event.id)?.original
-        if (originalPaymentMethod == null) {
-            handleInternalFailure("Failed to select payment method: it is null.")
-            return
-        }
-        dispatch(WillSelectPaymentMethod(paymentMethod = originalPaymentMethod))
         paymentMethod(event.id)?.let { paymentMethod ->
+            dispatch(WillSelectPaymentMethod(paymentMethod = paymentMethod.original))
+            resetPaymentMethods()
             if (_state.value.processingPaymentMethod != null) {
                 invalidateInvoice(
                     reason = PODynamicCheckoutInvoiceInvalidationReason.PaymentMethodChanged
                 )
-            }
-            resetPaymentMethods()
-            if (_state.value.isInvoiceValid) {
+            } else {
+                dispatch(DidSelectPaymentMethod(paymentMethod = paymentMethod.original))
                 start(paymentMethod)
             }
             _state.update {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -233,8 +233,8 @@ internal class DynamicCheckoutInteractor(
                     }
                 }
         }
-        _state.value.pendingSubmitPaymentMethodId?.let { id ->
-            _state.update { it.copy(pendingSubmitPaymentMethodId = null) }
+        _state.value.pendingSubmitPaymentMethod?.id?.let { id ->
+            _state.update { it.copy(pendingSubmitPaymentMethod = null) }
             paymentMethod(id)?.let { submit(it) }
                 .orElse {
                     _state.update {
@@ -553,7 +553,7 @@ internal class DynamicCheckoutInteractor(
             }
         }
         if (_state.value.processingPaymentMethodId != null) {
-            _state.update { it.copy(pendingSubmitPaymentMethodId = paymentMethod.id) }
+            _state.update { it.copy(pendingSubmitPaymentMethod = paymentMethod) }
             invalidateInvoice(
                 reason = PODynamicCheckoutInvoiceInvalidationReason.PaymentMethodChanged
             )

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -594,15 +594,7 @@ internal class DynamicCheckoutInteractor(
             return
         }
         when (paymentMethod) {
-            is GooglePay ->
-                interactorScope.launch {
-                    _state.update { it.copy(processingPaymentMethod = paymentMethod) }
-                    _submitEvents.send(
-                        DynamicCheckoutSubmitEvent.GooglePay(
-                            paymentDataRequest = paymentMethod.paymentDataRequest
-                        )
-                    )
-                }
+            is GooglePay -> submitGooglePay(paymentMethod)
             is AlternativePayment -> submitAlternativePayment(paymentMethod)
             is CustomerToken ->
                 if (paymentMethod.configuration.redirectUrl != null) {
@@ -612,6 +604,17 @@ internal class DynamicCheckoutInteractor(
                     authorizeInvoice(source = paymentMethod.configuration.customerTokenId)
                 }
             else -> {}
+        }
+    }
+
+    private fun submitGooglePay(paymentMethod: GooglePay) {
+        interactorScope.launch {
+            _state.update { it.copy(processingPaymentMethod = paymentMethod) }
+            _submitEvents.send(
+                DynamicCheckoutSubmitEvent.GooglePay(
+                    paymentDataRequest = paymentMethod.paymentDataRequest
+                )
+            )
         }
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -305,7 +305,7 @@ internal class DynamicCheckoutInteractor(
                 display = paymentMethod.display,
                 isExpress = paymentMethod.flow == express
             )
-            else -> null
+            Unknown -> null
         }
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -251,6 +251,7 @@ internal class DynamicCheckoutInteractor(
         when (paymentMethod) {
             is PODynamicCheckoutPaymentMethod.Card -> Card(
                 id = PaymentMethodId.CARD,
+                original = paymentMethod,
                 configuration = paymentMethod.configuration,
                 display = paymentMethod.display
             )
@@ -264,6 +265,7 @@ internal class DynamicCheckoutInteractor(
                 if (googlePayService.isReadyToPay(isReadyToPayRequest))
                     GooglePay(
                         id = paymentMethod.configuration.gatewayMerchantId,
+                        original = paymentMethod,
                         allowedPaymentMethods = POGooglePayRequestBuilder
                             .allowedPaymentMethods(configuration.card)
                             .toString(),
@@ -275,6 +277,7 @@ internal class DynamicCheckoutInteractor(
                 if (redirectUrl != null) {
                     AlternativePayment(
                         id = paymentMethod.configuration.gatewayConfigurationId,
+                        original = paymentMethod,
                         redirectUrl = redirectUrl,
                         display = paymentMethod.display,
                         isExpress = paymentMethod.flow == express
@@ -282,6 +285,7 @@ internal class DynamicCheckoutInteractor(
                 } else {
                     NativeAlternativePayment(
                         id = paymentMethod.configuration.gatewayConfigurationId,
+                        original = paymentMethod,
                         gatewayConfigurationId = paymentMethod.configuration.gatewayConfigurationId,
                         display = paymentMethod.display
                     )
@@ -289,12 +293,14 @@ internal class DynamicCheckoutInteractor(
             }
             is CardCustomerToken -> CustomerToken(
                 id = paymentMethod.configuration.customerTokenId,
+                original = paymentMethod,
                 configuration = paymentMethod.configuration,
                 display = paymentMethod.display,
                 isExpress = paymentMethod.flow == express
             )
             is AlternativePaymentCustomerToken -> CustomerToken(
                 id = paymentMethod.configuration.customerTokenId,
+                original = paymentMethod,
                 configuration = paymentMethod.configuration,
                 display = paymentMethod.display,
                 isExpress = paymentMethod.flow == express

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -118,7 +118,6 @@ internal class DynamicCheckoutInteractor(
     private suspend fun start() {
         handleCompletions()
         dispatchEvents()
-        dispatchFailure()
         collectInvoice()
         collectInvoiceAuthorizationRequest()
         collectAuthorizeInvoiceResult()
@@ -768,6 +767,17 @@ internal class DynamicCheckoutInteractor(
 
     private fun handleCompletions() {
         interactorScope.launch {
+            _completion.collect { completion ->
+                when (completion) {
+                    Success -> {
+                        // TODO
+                    }
+                    is Failure -> dispatch(DidFail(completion.failure))
+                    else -> {}
+                }
+            }
+        }
+        interactorScope.launch {
             cardTokenization.completion.collect { completion ->
                 when (completion) {
                     is CardTokenizationCompletion.Success -> handleSuccess()
@@ -816,16 +826,6 @@ internal class DynamicCheckoutInteractor(
                     _state.update { it.copy(processingPaymentMethodId = selectedPaymentMethod()?.id) }
                 }
                 eventDispatcher.send(event)
-            }
-        }
-    }
-
-    private fun dispatchFailure() {
-        interactorScope.launch {
-            _completion.collect {
-                if (it is Failure) {
-                    dispatch(DidFail(it.failure))
-                }
             }
         }
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -430,9 +430,6 @@ internal class DynamicCheckoutInteractor(
 
     //endregion
 
-    private fun paymentMethod(id: String): PaymentMethod? =
-        _state.value.paymentMethods.find { it.id == id }
-
     fun onEvent(event: DynamicCheckoutEvent) {
         when (event) {
             is PaymentMethodSelected -> onPaymentMethodSelected(event)
@@ -443,6 +440,9 @@ internal class DynamicCheckoutInteractor(
             is Dismiss -> dismiss(event)
         }
     }
+
+    private fun paymentMethod(id: String): PaymentMethod? =
+        _state.value.paymentMethods.find { it.id == id }
 
     private fun onPaymentMethodSelected(event: PaymentMethodSelected) {
         if (event.id == _state.value.selectedPaymentMethod?.id) {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -115,6 +115,15 @@ internal class DynamicCheckoutInteractor(
         }
     }
 
+    private fun initState() = DynamicCheckoutInteractorState(
+        loading = true,
+        invoice = POInvoice(id = configuration.invoiceRequest.invoiceId),
+        isInvoiceValid = false,
+        paymentMethods = emptyList(),
+        submitActionId = ActionId.SUBMIT,
+        cancelActionId = ActionId.CANCEL
+    )
+
     private suspend fun start() {
         handleCompletions()
         dispatchEvents()
@@ -185,15 +194,6 @@ internal class DynamicCheckoutInteractor(
         cardTokenization.reset()
         nativeAlternativePayment.reset()
     }
-
-    private fun initState() = DynamicCheckoutInteractorState(
-        loading = true,
-        invoice = POInvoice(id = configuration.invoiceRequest.invoiceId),
-        isInvoiceValid = false,
-        paymentMethods = emptyList(),
-        submitActionId = ActionId.SUBMIT,
-        cancelActionId = ActionId.CANCEL
-    )
 
     private suspend fun fetchConfiguration() {
         invoicesService.invoice(configuration.invoiceRequest)

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -131,6 +131,7 @@ internal class DynamicCheckoutInteractor(
         collectInvoiceAuthorizationRequest()
         collectAuthorizeInvoiceResult()
         collectTokenizedCard()
+        collectDefaultValues()
         fetchConfiguration()
     }
 
@@ -850,6 +851,21 @@ internal class DynamicCheckoutInteractor(
                     _state.update { it.copy(processingPaymentMethod = _state.value.selectedPaymentMethod) }
                 }
                 eventDispatcher.send(event)
+            }
+        }
+        interactorScope.launch {
+            nativeAlternativePaymentEventDispatcher.defaultValuesRequest.collect { request ->
+                eventDispatcher.send(request)
+            }
+        }
+    }
+
+    private fun collectDefaultValues() {
+        eventDispatcher.subscribeForResponse<PONativeAlternativePaymentMethodDefaultValuesResponse>(
+            coroutineScope = interactorScope
+        ) { response ->
+            interactorScope.launch {
+                nativeAlternativePaymentEventDispatcher.provideDefaultValues(response)
             }
         }
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -158,10 +158,14 @@ internal class DynamicCheckoutInteractor(
     private fun reset(state: DynamicCheckoutInteractorState) {
         interactorScope.coroutineContext.cancelChildren()
         latestInvoiceRequest = null
-        cardTokenization.reset()
-        nativeAlternativePayment.reset()
+        resetPaymentMethods()
         _completion.update { Awaiting }
         _state.update { state }
+    }
+
+    private fun resetPaymentMethods() {
+        cardTokenization.reset()
+        nativeAlternativePayment.reset()
     }
 
     private fun initState() = DynamicCheckoutInteractorState(
@@ -446,8 +450,7 @@ internal class DynamicCheckoutInteractor(
                     reason = PODynamicCheckoutInvoiceInvalidationReason.PaymentMethodChanged
                 )
             }
-            cardTokenization.reset()
-            nativeAlternativePayment.reset()
+            resetPaymentMethods()
             if (_state.value.isInvoiceValid) {
                 start(paymentMethod)
             }
@@ -548,8 +551,7 @@ internal class DynamicCheckoutInteractor(
             return
         }
         if (paymentMethod.isExpress()) {
-            cardTokenization.reset()
-            nativeAlternativePayment.reset()
+            resetPaymentMethods()
             _state.update {
                 it.copy(
                     selectedPaymentMethodId = null,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -702,12 +702,7 @@ internal class DynamicCheckoutInteractor(
         allowFallbackToSale: Boolean = false,
         clientSecret: String? = null
     ) {
-        val paymentMethodId = _state.value.processingPaymentMethod?.id
-        if (paymentMethodId == null) {
-            handleInternalFailure("Failed to authorize invoice: payment method ID is null.")
-            return
-        }
-        val paymentMethod = paymentMethod(paymentMethodId)
+        val paymentMethod = _state.value.processingPaymentMethod
         if (paymentMethod == null) {
             handleInternalFailure("Failed to authorize invoice: payment method is null.")
             return

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -13,7 +13,7 @@ import com.processout.sdk.api.dispatcher.POEventDispatcher
 import com.processout.sdk.api.dispatcher.card.tokenization.PODefaultCardTokenizationEventDispatcher
 import com.processout.sdk.api.dispatcher.napm.PODefaultNativeAlternativePaymentMethodEventDispatcher
 import com.processout.sdk.api.model.event.PODynamicCheckoutEvent
-import com.processout.sdk.api.model.event.PODynamicCheckoutEvent.DidFail
+import com.processout.sdk.api.model.event.PODynamicCheckoutEvent.*
 import com.processout.sdk.api.model.event.PONativeAlternativePaymentMethodEvent.WillSubmitParameters
 import com.processout.sdk.api.model.request.*
 import com.processout.sdk.api.model.response.*
@@ -107,7 +107,11 @@ internal class DynamicCheckoutInteractor(
 
     init {
         interactorScope.launch {
+            POLogger.info("Starting dynamic checkout.")
+            dispatch(WillStart)
             start()
+            POLogger.info("Started: waiting for user input.")
+            dispatch(DidStart)
         }
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -409,7 +409,10 @@ internal class DynamicCheckoutInteractor(
             is FieldFocusChanged -> onFieldFocusChanged(event)
             is Action -> onAction(event)
             is ActionConfirmationRequested -> {
-                // TODO
+                POLogger.debug("Requested the user to confirm the action: %s", event.id)
+                if (event.id == ActionId.CANCEL) {
+                    dispatch(DidRequestCancelConfirmation)
+                }
             }
             is Dismiss -> {
                 if (_state.value.delayedSuccess) {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -754,8 +754,8 @@ internal class DynamicCheckoutInteractor(
         interactorScope.launch {
             _completion.collect { completion ->
                 when (completion) {
-                    Success -> {
-                        // TODO
+                    Success -> _state.value.processingPaymentMethod?.let { paymentMethod ->
+                        dispatch(DidCompletePayment(paymentMethod.original))
                     }
                     is Failure -> dispatch(DidFail(completion.failure))
                     else -> {}

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -596,13 +596,7 @@ internal class DynamicCheckoutInteractor(
         when (paymentMethod) {
             is GooglePay -> submitGooglePay(paymentMethod)
             is AlternativePayment -> submitAlternativePayment(paymentMethod)
-            is CustomerToken ->
-                if (paymentMethod.configuration.redirectUrl != null) {
-                    submitAlternativePayment(paymentMethod)
-                } else {
-                    _state.update { it.copy(processingPaymentMethod = paymentMethod) }
-                    authorizeInvoice(source = paymentMethod.configuration.customerTokenId)
-                }
+            is CustomerToken -> submitCustomerToken(paymentMethod)
             else -> {}
         }
     }
@@ -651,6 +645,15 @@ internal class DynamicCheckoutInteractor(
                     returnUrl = returnUrl
                 )
             )
+        }
+    }
+
+    private fun submitCustomerToken(paymentMethod: CustomerToken) {
+        if (paymentMethod.configuration.redirectUrl != null) {
+            submitAlternativePayment(paymentMethod)
+        } else {
+            _state.update { it.copy(processingPaymentMethod = paymentMethod) }
+            authorizeInvoice(source = paymentMethod.configuration.customerTokenId)
         }
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -748,7 +748,7 @@ internal class DynamicCheckoutInteractor(
         interactorScope.launch {
             val request = PODynamicCheckoutInvoiceAuthorizationRequest(
                 request = POInvoiceAuthorizationRequest(
-                    invoiceId = _state.value.invoice.id,
+                    invoiceId = configuration.invoiceRequest.invoiceId,
                     source = source,
                     saveSource = saveSource,
                     allowFallbackToSale = allowFallbackToSale,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -647,14 +647,6 @@ internal class DynamicCheckoutInteractor(
         }
     }
 
-    private fun handleInternalFailure(message: String) {
-        invalidateInvoice(
-            reason = PODynamicCheckoutInvoiceInvalidationReason.Failure(
-                failure = ProcessOutResult.Failure(code = Internal(), message = message)
-            )
-        )
-    }
-
     private fun invalidateInvoice(reason: PODynamicCheckoutInvoiceInvalidationReason) {
         interactorScope.launch {
             _state.update { it.copy(isInvoiceValid = false) }
@@ -716,7 +708,14 @@ internal class DynamicCheckoutInteractor(
     ) {
         val paymentMethod = _state.value.processingPaymentMethod
         if (paymentMethod == null) {
-            handleInternalFailure("Failed to authorize invoice: payment method is null.")
+            invalidateInvoice(
+                reason = PODynamicCheckoutInvoiceInvalidationReason.Failure(
+                    failure = ProcessOutResult.Failure(
+                        code = Internal(),
+                        message = "Failed to authorize invoice: payment method is null."
+                    )
+                )
+            )
             return
         }
         interactorScope.launch {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -439,12 +439,7 @@ internal class DynamicCheckoutInteractor(
             is FieldValueChanged -> onFieldValueChanged(event)
             is FieldFocusChanged -> onFieldFocusChanged(event)
             is Action -> onAction(event)
-            is ActionConfirmationRequested -> {
-                POLogger.debug("Requested the user to confirm the action: %s", event.id)
-                if (event.id == ActionId.CANCEL) {
-                    dispatch(DidRequestCancelConfirmation)
-                }
-            }
+            is ActionConfirmationRequested -> onActionConfirmationRequested(event)
             is Dismiss -> {
                 if (_state.value.delayedSuccess) {
                     _completion.update { Success }
@@ -556,6 +551,13 @@ internal class DynamicCheckoutInteractor(
                 )
                 else -> {}
             }
+        }
+    }
+
+    private fun onActionConfirmationRequested(event: ActionConfirmationRequested) {
+        POLogger.debug("Requested the user to confirm the action: %s", event.id)
+        if (event.id == ActionId.CANCEL) {
+            dispatch(DidRequestCancelConfirmation)
         }
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -222,6 +222,11 @@ internal class DynamicCheckoutInteractor(
                 paymentMethods = mappedPaymentMethods
             )
         }
+        restoreSelectedPaymentMethod()
+        handlePendingSubmit()
+    }
+
+    private fun restoreSelectedPaymentMethod() {
         _state.value.selectedPaymentMethod?.id?.let { id ->
             paymentMethod(id)?.let { start(it) }
                 .orElse {
@@ -233,6 +238,9 @@ internal class DynamicCheckoutInteractor(
                     }
                 }
         }
+    }
+
+    private fun handlePendingSubmit() {
         _state.value.pendingSubmitPaymentMethod?.id?.let { id ->
             _state.update { it.copy(pendingSubmitPaymentMethod = null) }
             paymentMethod(id)?.let {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -440,14 +440,7 @@ internal class DynamicCheckoutInteractor(
             is FieldFocusChanged -> onFieldFocusChanged(event)
             is Action -> onAction(event)
             is ActionConfirmationRequested -> onActionConfirmationRequested(event)
-            is Dismiss -> {
-                if (_state.value.delayedSuccess) {
-                    _completion.update { Success }
-                } else {
-                    POLogger.warn("Dismissed: %s", event.failure)
-                    _completion.update { Failure(event.failure) }
-                }
-            }
+            is Dismiss -> dismiss(event)
         }
     }
 
@@ -869,6 +862,15 @@ internal class DynamicCheckoutInteractor(
                     message = "Cancelled by the user with cancel action."
                 ).also { POLogger.info("Cancelled: %s", it) }
             )
+        }
+    }
+
+    private fun dismiss(event: Dismiss) {
+        if (_state.value.delayedSuccess) {
+            _completion.update { Success }
+        } else {
+            POLogger.warn("Dismissed: %s", event.failure)
+            _completion.update { Failure(event.failure) }
         }
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractorState.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractorState.kt
@@ -14,7 +14,7 @@ internal data class DynamicCheckoutInteractorState(
     val cancelActionId: String,
     val selectedPaymentMethodId: String? = null,
     val processingPaymentMethodId: String? = null,
-    val pendingSubmitPaymentMethodId: String? = null,
+    val pendingSubmitPaymentMethod: PaymentMethod? = null,
     val errorMessage: String? = null,
     val delayedSuccess: Boolean = false
 ) {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractorState.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractorState.kt
@@ -12,7 +12,7 @@ internal data class DynamicCheckoutInteractorState(
     val paymentMethods: List<PaymentMethod>,
     val submitActionId: String,
     val cancelActionId: String,
-    val selectedPaymentMethodId: String? = null,
+    val selectedPaymentMethod: PaymentMethod? = null,
     val processingPaymentMethodId: String? = null,
     val pendingSubmitPaymentMethod: PaymentMethod? = null,
     val errorMessage: String? = null,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractorState.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractorState.kt
@@ -13,7 +13,7 @@ internal data class DynamicCheckoutInteractorState(
     val submitActionId: String,
     val cancelActionId: String,
     val selectedPaymentMethod: PaymentMethod? = null,
-    val processingPaymentMethodId: String? = null,
+    val processingPaymentMethod: PaymentMethod? = null,
     val pendingSubmitPaymentMethod: PaymentMethod? = null,
     val errorMessage: String? = null,
     val delayedSuccess: Boolean = false

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractorState.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractorState.kt
@@ -1,5 +1,6 @@
 package com.processout.sdk.ui.checkout
 
+import com.processout.sdk.api.model.response.PODynamicCheckoutPaymentMethod
 import com.processout.sdk.api.model.response.PODynamicCheckoutPaymentMethod.*
 import com.processout.sdk.api.model.response.POInvoice
 import org.json.JSONObject
@@ -21,21 +22,25 @@ internal data class DynamicCheckoutInteractorState(
     sealed interface PaymentMethod {
 
         val id: String
+        val original: PODynamicCheckoutPaymentMethod
 
         data class Card(
             override val id: String,
+            override val original: PODynamicCheckoutPaymentMethod,
             val configuration: CardConfiguration,
             val display: Display
         ) : PaymentMethod
 
         data class GooglePay(
             override val id: String,
+            override val original: PODynamicCheckoutPaymentMethod,
             val allowedPaymentMethods: String,
             val paymentDataRequest: JSONObject
         ) : PaymentMethod
 
         data class AlternativePayment(
             override val id: String,
+            override val original: PODynamicCheckoutPaymentMethod,
             val redirectUrl: String,
             val display: Display,
             val isExpress: Boolean
@@ -43,12 +48,14 @@ internal data class DynamicCheckoutInteractorState(
 
         data class NativeAlternativePayment(
             override val id: String,
+            override val original: PODynamicCheckoutPaymentMethod,
             val gatewayConfigurationId: String,
             val display: Display
         ) : PaymentMethod
 
         data class CustomerToken(
             override val id: String,
+            override val original: PODynamicCheckoutPaymentMethod,
             val configuration: CustomerTokenConfiguration,
             val display: Display,
             val isExpress: Boolean

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
@@ -198,12 +198,14 @@ internal class DynamicCheckoutViewModel private constructor(
                 is AlternativePayment -> if (paymentMethod.isExpress)
                     expressPayment(
                         id = id,
+                        text = paymentMethod.display.name,
                         display = paymentMethod.display,
                         interactorState = interactorState
                     ) else null
                 is CustomerToken -> if (paymentMethod.isExpress)
                     expressPayment(
                         id = id,
+                        text = paymentMethod.display.description ?: paymentMethod.display.name,
                         display = paymentMethod.display,
                         interactorState = interactorState
                     ) else null
@@ -213,6 +215,7 @@ internal class DynamicCheckoutViewModel private constructor(
 
     private fun expressPayment(
         id: String,
+        text: String,
         display: Display,
         interactorState: DynamicCheckoutInteractorState
     ) = ExpressPayment.Express(
@@ -221,7 +224,7 @@ internal class DynamicCheckoutViewModel private constructor(
         brandColor = display.brandColor,
         submitAction = POActionState(
             id = interactorState.submitActionId,
-            text = display.name,
+            text = text,
             primary = true,
             enabled = id != interactorState.processingPaymentMethod?.id
         )

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
@@ -166,7 +166,7 @@ internal class DynamicCheckoutViewModel private constructor(
         id = interactorState.cancelActionId,
         text = text ?: defaultText,
         primary = false,
-        enabled = interactorState.processingPaymentMethodId == null,
+        enabled = interactorState.processingPaymentMethod == null,
         confirmation = confirmation?.map()
     )
 
@@ -192,7 +192,7 @@ internal class DynamicCheckoutViewModel private constructor(
                         id = interactorState.submitActionId,
                         text = String(),
                         primary = true,
-                        enabled = id != interactorState.processingPaymentMethodId
+                        enabled = id != interactorState.processingPaymentMethod?.id
                     )
                 )
                 is AlternativePayment -> if (paymentMethod.isExpress)
@@ -223,7 +223,7 @@ internal class DynamicCheckoutViewModel private constructor(
             id = interactorState.submitActionId,
             text = display.name,
             primary = true,
-            enabled = id != interactorState.processingPaymentMethodId
+            enabled = id != interactorState.processingPaymentMethod?.id
         )
     )
 
@@ -261,7 +261,7 @@ internal class DynamicCheckoutViewModel private constructor(
                             id = interactorState.submitActionId,
                             text = submitButtonText,
                             primary = true,
-                            loading = interactorState.processingPaymentMethodId != null
+                            loading = interactorState.processingPaymentMethod != null
                         )
                     ) else null
                 is NativeAlternativePayment -> RegularPayment(

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
@@ -17,7 +17,6 @@ import com.processout.sdk.api.service.proxy3ds.PODefaultProxy3DSService
 import com.processout.sdk.core.ProcessOutResult
 import com.processout.sdk.ui.card.tokenization.CardTokenizationViewModel
 import com.processout.sdk.ui.card.tokenization.CardTokenizationViewModelState
-import com.processout.sdk.ui.checkout.DynamicCheckoutInteractorState.PaymentMethod
 import com.processout.sdk.ui.checkout.DynamicCheckoutInteractorState.PaymentMethod.*
 import com.processout.sdk.ui.checkout.DynamicCheckoutViewModelState.*
 import com.processout.sdk.ui.checkout.DynamicCheckoutViewModelState.RegularPayment.Content
@@ -124,9 +123,6 @@ internal class DynamicCheckoutViewModel private constructor(
         }
     }
 
-    private fun DynamicCheckoutInteractorState.selectedPaymentMethod(): PaymentMethod? =
-        paymentMethods.find { it.id == selectedPaymentMethodId }
-
     private fun cancelAction(
         interactorState: DynamicCheckoutInteractorState,
         cardTokenizationState: CardTokenizationViewModelState,
@@ -135,7 +131,7 @@ internal class DynamicCheckoutViewModel private constructor(
         val defaultText = app.getString(R.string.po_dynamic_checkout_button_cancel)
         val defaultCancelAction = configuration.cancelButton?.toActionState(interactorState, defaultText)
         val defaultCancelActionText = defaultCancelAction?.text ?: defaultText
-        return when (interactorState.selectedPaymentMethod()) {
+        return when (interactorState.selectedPaymentMethod) {
             is Card -> cardTokenizationState.secondaryAction?.copy(
                 text = defaultCancelActionText,
                 confirmation = defaultCancelAction?.confirmation
@@ -238,7 +234,7 @@ internal class DynamicCheckoutViewModel private constructor(
     ): POImmutableList<RegularPayment> =
         interactorState.paymentMethods.mapNotNull { paymentMethod ->
             val id = paymentMethod.id
-            val selected = id == interactorState.selectedPaymentMethodId
+            val selected = id == interactorState.selectedPaymentMethod?.id
             val submitButtonText = configuration.submitButtonText ?: app.getString(R.string.po_dynamic_checkout_button_pay)
             when (paymentMethod) {
                 is Card -> RegularPayment(

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutDelegate.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutDelegate.kt
@@ -6,6 +6,7 @@ import com.processout.sdk.api.model.event.PONativeAlternativePaymentMethodEvent
 import com.processout.sdk.api.model.request.PODynamicCheckoutInvoiceInvalidationReason
 import com.processout.sdk.api.model.request.POInvoiceAuthorizationRequest
 import com.processout.sdk.api.model.request.POInvoiceRequest
+import com.processout.sdk.api.model.request.PONativeAlternativePaymentMethodDefaultValuesRequest
 import com.processout.sdk.api.model.response.PODynamicCheckoutPaymentMethod
 import com.processout.sdk.api.model.response.POInvoice
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
@@ -36,4 +37,8 @@ interface PODynamicCheckoutDelegate {
         request: POInvoiceAuthorizationRequest,
         paymentMethod: PODynamicCheckoutPaymentMethod
     ): POInvoiceAuthorizationRequest = request
+
+    suspend fun defaultValues(
+        request: PONativeAlternativePaymentMethodDefaultValuesRequest
+    ): Map<String, String> = emptyMap()
 }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutDelegate.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutDelegate.kt
@@ -3,10 +3,7 @@ package com.processout.sdk.ui.checkout
 import com.processout.sdk.api.model.event.POCardTokenizationEvent
 import com.processout.sdk.api.model.event.PODynamicCheckoutEvent
 import com.processout.sdk.api.model.event.PONativeAlternativePaymentMethodEvent
-import com.processout.sdk.api.model.request.PODynamicCheckoutInvoiceInvalidationReason
-import com.processout.sdk.api.model.request.POInvoiceAuthorizationRequest
-import com.processout.sdk.api.model.request.POInvoiceRequest
-import com.processout.sdk.api.model.request.PONativeAlternativePaymentMethodDefaultValuesRequest
+import com.processout.sdk.api.model.request.*
 import com.processout.sdk.api.model.response.PODynamicCheckoutPaymentMethod
 import com.processout.sdk.api.model.response.POInvoice
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
@@ -37,6 +34,10 @@ interface PODynamicCheckoutDelegate {
         request: POInvoiceAuthorizationRequest,
         paymentMethod: PODynamicCheckoutPaymentMethod
     ): POInvoiceAuthorizationRequest = request
+
+    suspend fun preferredScheme(
+        request: POCardTokenizationPreferredSchemeRequest
+    ): String? = null
 
     suspend fun defaultValues(
         request: PONativeAlternativePaymentMethodDefaultValuesRequest

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutDelegate.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutDelegate.kt
@@ -1,6 +1,7 @@
 package com.processout.sdk.ui.checkout
 
 import com.processout.sdk.api.model.event.POCardTokenizationEvent
+import com.processout.sdk.api.model.event.PODynamicCheckoutEvent
 import com.processout.sdk.api.model.event.PONativeAlternativePaymentMethodEvent
 import com.processout.sdk.api.model.request.PODynamicCheckoutInvoiceInvalidationReason
 import com.processout.sdk.api.model.request.POInvoiceAuthorizationRequest
@@ -12,6 +13,8 @@ import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 /** @suppress */
 @ProcessOutInternalApi
 interface PODynamicCheckoutDelegate {
+
+    fun onEvent(event: PODynamicCheckoutEvent) {}
 
     fun onEvent(event: POCardTokenizationEvent) {}
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutLauncher.kt
@@ -12,6 +12,7 @@ import com.processout.sdk.api.model.event.PODynamicCheckoutEvent
 import com.processout.sdk.api.model.event.PONativeAlternativePaymentMethodEvent
 import com.processout.sdk.api.model.request.PODynamicCheckoutInvoiceAuthorizationRequest
 import com.processout.sdk.api.model.request.PODynamicCheckoutInvoiceRequest
+import com.processout.sdk.api.model.request.PONativeAlternativePaymentMethodDefaultValuesRequest
 import com.processout.sdk.api.model.response.toResponse
 import com.processout.sdk.api.service.PO3DSService
 import com.processout.sdk.api.service.proxy3ds.POProxy3DSServiceRequest
@@ -89,6 +90,7 @@ class PODynamicCheckoutLauncher private constructor(
         dispatchEvents()
         dispatchInvoice()
         dispatchInvoiceAuthorizationRequest()
+        dispatchDefaultValues()
         dispatch3DSService()
     }
 
@@ -128,6 +130,17 @@ class PODynamicCheckoutLauncher private constructor(
                     paymentMethod = request.paymentMethod
                 )
                 eventDispatcher.send(request.toResponse(invoiceAuthorizationRequest))
+            }
+        }
+    }
+
+    private fun dispatchDefaultValues() {
+        eventDispatcher.subscribeForRequest<PONativeAlternativePaymentMethodDefaultValuesRequest>(
+            coroutineScope = scope
+        ) { request ->
+            scope.launch {
+                val defaultValues = delegate.defaultValues(request)
+                eventDispatcher.send(request.toResponse(defaultValues))
             }
         }
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutLauncher.kt
@@ -10,6 +10,7 @@ import com.processout.sdk.api.dispatcher.POEventDispatcher
 import com.processout.sdk.api.model.event.POCardTokenizationEvent
 import com.processout.sdk.api.model.event.PODynamicCheckoutEvent
 import com.processout.sdk.api.model.event.PONativeAlternativePaymentMethodEvent
+import com.processout.sdk.api.model.request.POCardTokenizationPreferredSchemeRequest
 import com.processout.sdk.api.model.request.PODynamicCheckoutInvoiceAuthorizationRequest
 import com.processout.sdk.api.model.request.PODynamicCheckoutInvoiceRequest
 import com.processout.sdk.api.model.request.PONativeAlternativePaymentMethodDefaultValuesRequest
@@ -90,6 +91,7 @@ class PODynamicCheckoutLauncher private constructor(
         dispatchEvents()
         dispatchInvoice()
         dispatchInvoiceAuthorizationRequest()
+        dispatchPreferredScheme()
         dispatchDefaultValues()
         dispatch3DSService()
     }
@@ -130,6 +132,17 @@ class PODynamicCheckoutLauncher private constructor(
                     paymentMethod = request.paymentMethod
                 )
                 eventDispatcher.send(request.toResponse(invoiceAuthorizationRequest))
+            }
+        }
+    }
+
+    private fun dispatchPreferredScheme() {
+        eventDispatcher.subscribeForRequest<POCardTokenizationPreferredSchemeRequest>(
+            coroutineScope = scope
+        ) { request ->
+            scope.launch {
+                val preferredScheme = delegate.preferredScheme(request)
+                eventDispatcher.send(request.toResponse(preferredScheme))
             }
         }
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutLauncher.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.processout.sdk.api.dispatcher.POEventDispatcher
 import com.processout.sdk.api.model.event.POCardTokenizationEvent
+import com.processout.sdk.api.model.event.PODynamicCheckoutEvent
 import com.processout.sdk.api.model.event.PONativeAlternativePaymentMethodEvent
 import com.processout.sdk.api.model.request.PODynamicCheckoutInvoiceAuthorizationRequest
 import com.processout.sdk.api.model.request.PODynamicCheckoutInvoiceRequest
@@ -92,6 +93,9 @@ class PODynamicCheckoutLauncher private constructor(
     }
 
     private fun dispatchEvents() {
+        eventDispatcher.subscribe<PODynamicCheckoutEvent>(
+            coroutineScope = scope
+        ) { delegate.onEvent(it) }
         eventDispatcher.subscribe<POCardTokenizationEvent>(
             coroutineScope = scope
         ) { delegate.onEvent(it) }


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Refactored:
1) Added `val original: PODynamicCheckoutPaymentMethod` to all internal `PaymentMethod` interactor types. It is needed for lifecycle events and make it easy to access the original type without the need to lookup for it.
2) Changed `DynamicCheckoutInteractorState` to keep the whole `PaymentMethod` object instead of only IDs for the following states (allows to avoid lookup for the object by id and simplifies the logic):
selectedPaymentMethodId -> selectedPaymentMethod
processingPaymentMethodId -> processingPaymentMethod
pendingSubmitPaymentMethodId -> pendingSubmitPaymentMethod
3) Refactored startup concurrency to send lifecycle events at correct moment.
4) Extracted some methods for readability.

Added:
1) `PODynamicCheckoutEvent` and sending all lifecycle events.
2) `PODynamicCheckoutDelegate` dispatching `preferredScheme` (for card) and `defaultValues` (for nAPM).
3) Added `PODynamicCheckoutPaymentMethod.Display.description`, it used as text for customer token payment types (card and APM) with fallback to `display.name` when null.
4) `logAttributes` but not used yet, logs will be added in separate PR.

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-419
