### PR TITLE
fix(ad-hoc): Fix DidCompletePayment event on DC

### DIFF
--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PODynamicCheckoutEvent.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/event/PODynamicCheckoutEvent.kt
@@ -43,9 +43,7 @@ sealed class PODynamicCheckoutEvent {
     /**
      * Event is sent after payment was confirmed to be captured. This is a final event.
      */
-    data class DidCompletePayment(
-        val paymentMethod: PODynamicCheckoutPaymentMethod
-    ) : PODynamicCheckoutEvent()
+    data object DidCompletePayment : PODynamicCheckoutEvent()
 
     /**
      * Event is sent when unretryable error occurs. This is a final event.

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -840,9 +840,7 @@ internal class DynamicCheckoutInteractor(
         interactorScope.launch {
             _completion.collect { completion ->
                 when (completion) {
-                    Success -> _state.value.processingPaymentMethod?.let { paymentMethod ->
-                        dispatch(DidCompletePayment(paymentMethod.original))
-                    }
+                    Success -> dispatch(DidCompletePayment)
                     is Failure -> dispatch(DidFail(completion.failure))
                     else -> {}
                 }


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Removed `paymentMethod` from `DidCompletePayment` event as we don't know what method was used if invoice is already captured on DC start. Event will be sent in this case as well.
