### PR TITLE
fix(POM-438): (DC) Fix transition to success screen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ ext {
     androidxSwipeRefreshLayoutVersion = '1.1.0'
     androidxBrowserVersion = '1.8.0'
 
-    androidxComposeBOMVersion = '2024.10.01'
+    androidxComposeBOMVersion = '2024.11.00'
     composeGooglePayButtonVersion = '1.0.0'
 
     materialVersion = '1.12.0'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         kotlinVersion = '2.0.21'
         kspVersion = '2.0.21-1.0.27'
         dokkaVersion = '1.9.20'
-        androidxNavigationVersion = '2.8.3'
+        androidxNavigationVersion = '2.8.4'
         nexusPublishPluginVersion = '2.0.0'
     }
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        androidGradlePluginVersion = '8.7.1'
+        androidGradlePluginVersion = '8.7.3'
         kotlinVersion = '2.0.21'
         kspVersion = '2.0.21-1.0.27'
         dokkaVersion = '1.9.20'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Oct 05 19:43:19 EEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/DynamicCheckoutScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/DynamicCheckoutScreen.kt
@@ -106,30 +106,33 @@ internal fun DynamicCheckoutScreen(
                 }
             }
         ) { scaffoldPadding ->
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(scaffoldPadding)
-                    .verticalScroll(rememberScrollState()),
-                verticalArrangement = if (state is Starting) Arrangement.Center else Arrangement.Top,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                when (state) {
-                    is Starting -> Loading(progressIndicatorColor = style.progressIndicatorColor)
-                    is Started -> Crossfade(
-                        targetState = state.successMessage != null,
-                        animationSpec = tween(
-                            durationMillis = CrossfadeAnimationDurationMillis,
-                            easing = LinearEasing
-                        )
-                    ) { isSuccess ->
-                        if (isSuccess) {
-                            Success(
-                                message = state.successMessage ?: String(),
-                                style = style.paymentSuccess
-                            )
-                        } else {
-                            Content(
+            Crossfade(
+                targetState = when (state) {
+                    is Started -> state.successMessage != null
+                    else -> false
+                },
+                animationSpec = tween(
+                    durationMillis = CrossfadeAnimationDurationMillis,
+                    easing = LinearEasing
+                )
+            ) { isSuccess ->
+                if (isSuccess && state is Started) {
+                    Success(
+                        message = state.successMessage ?: String(),
+                        style = style.paymentSuccess
+                    )
+                } else {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(scaffoldPadding)
+                            .verticalScroll(rememberScrollState()),
+                        verticalArrangement = if (state is Starting) Arrangement.Center else Arrangement.Top,
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        when (state) {
+                            is Starting -> Loading(progressIndicatorColor = style.progressIndicatorColor)
+                            is Started -> Content(
                                 state = state,
                                 onEvent = onEvent,
                                 style = style,
@@ -567,7 +570,7 @@ private fun Success(
 ) {
     Column(
         modifier = Modifier
-            .fillMaxWidth()
+            .fillMaxSize()
             .padding(top = spacing.extraLarge * 2),
         verticalArrangement = Arrangement.spacedBy(spacing.extraLarge),
         horizontalAlignment = Alignment.CenterHorizontally


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Move success screen crossfade out of main scrollable container, so it doesn't jump during transition if content is scrolled.

Compose `2024.11.00`

**Bug:**

[success_bug.webm](https://github.com/user-attachments/assets/d61d4e7a-0593-4dca-abb0-fce704f4b5d0)

**Fixed:**

[success_fixed.webm](https://github.com/user-attachments/assets/0c8c87f3-4586-4eb7-9de0-c59f760d017b)


## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-438
