### PR TITLE
feat(POM-442): Extend screens customization options

### DIFF
--- a/example/src/main/kotlin/com/processout/example/ui/screen/card/payment/CardPaymentFragment.kt
+++ b/example/src/main/kotlin/com/processout/example/ui/screen/card/payment/CardPaymentFragment.kt
@@ -27,6 +27,7 @@ import com.processout.sdk.core.ProcessOutActivityResult
 import com.processout.sdk.core.onFailure
 import com.processout.sdk.core.onSuccess
 import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration
+import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration.SubmitButton
 import com.processout.sdk.ui.card.tokenization.POCardTokenizationLauncher
 import com.processout.sdk.ui.shared.view.dialog.POAlertDialog
 import com.processout.sdk.ui.threeds.PO3DSRedirectCustomTabLauncher
@@ -98,7 +99,8 @@ class CardPaymentFragment : BaseFragment<FragmentCardPaymentBinding>(
         viewModel.onTokenizing()
         launcher.launch(
             POCardTokenizationConfiguration(
-                savingAllowed = true
+                savingAllowed = true,
+                submitButton = SubmitButton()
             )
         )
     }

--- a/example/src/main/kotlin/com/processout/example/ui/screen/checkout/DynamicCheckoutFragment.kt
+++ b/example/src/main/kotlin/com/processout/example/ui/screen/checkout/DynamicCheckoutFragment.kt
@@ -26,7 +26,7 @@ import com.processout.sdk.core.onSuccess
 import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration
 import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration.AlternativePaymentConfiguration
 import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration.AlternativePaymentConfiguration.PaymentConfirmationConfiguration
-import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration.AlternativePaymentConfiguration.PaymentConfirmationConfiguration.ConfirmButton
+import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration.SubmitButton
 import com.processout.sdk.ui.checkout.PODynamicCheckoutLauncher
 import com.processout.sdk.ui.shared.view.dialog.POAlertDialog
 import com.processout.sdk.ui.threeds.PO3DSRedirectCustomTabLauncher
@@ -99,7 +99,7 @@ class DynamicCheckoutFragment : BaseFragment<FragmentDynamicCheckoutBinding>(
                 alternativePayment = AlternativePaymentConfiguration(
                     returnUrl = Constants.RETURN_URL,
                     paymentConfirmation = PaymentConfirmationConfiguration(
-                        confirmButton = ConfirmButton()
+                        confirmButton = SubmitButton()
                     )
                 )
             )

--- a/example/src/main/kotlin/com/processout/example/ui/screen/features/FeaturesFragment.kt
+++ b/example/src/main/kotlin/com/processout/example/ui/screen/features/FeaturesFragment.kt
@@ -98,7 +98,6 @@ class FeaturesFragment : BaseFragment<FragmentFeaturesBinding>(
                                 preferredScheme = card?.coScheme
                             ),
                             cancellation = POCancellationConfiguration(
-                                secondaryAction = true,
                                 backPressed = true,
                                 dragDown = true,
                                 touchOutside = false

--- a/example/src/main/kotlin/com/processout/example/ui/screen/features/FeaturesFragment.kt
+++ b/example/src/main/kotlin/com/processout/example/ui/screen/features/FeaturesFragment.kt
@@ -20,6 +20,7 @@ import com.processout.sdk.api.model.response.POCard
 import com.processout.sdk.api.model.response.POGooglePayCardTokenizationData
 import com.processout.sdk.core.*
 import com.processout.sdk.ui.card.update.POCardUpdateConfiguration
+import com.processout.sdk.ui.card.update.POCardUpdateConfiguration.*
 import com.processout.sdk.ui.card.update.POCardUpdateLauncher
 import com.processout.sdk.ui.googlepay.POGooglePayCardTokenizationLauncher
 import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
@@ -90,13 +91,14 @@ class FeaturesFragment : BaseFragment<FragmentFeaturesBinding>(
                 cardUpdateLauncher.launch(
                     POCardUpdateConfiguration(
                         cardId = card?.id ?: String(),
-                        options = POCardUpdateConfiguration.Options(
-                            cardInformation = POCardUpdateConfiguration.CardInformation(
+                        options = Options(
+                            cardInformation = CardInformation(
                                 maskedNumber = maskedNumber,
                                 iin = card?.iin,
                                 scheme = card?.scheme,
                                 preferredScheme = card?.coScheme
                             ),
+                            submitButton = SubmitButton(),
                             cancellation = POCancellationConfiguration(
                                 backPressed = true,
                                 dragDown = true,

--- a/sdk/src/main/res/values-ar/strings.xml
+++ b/sdk/src/main/res/values-ar/strings.xml
@@ -92,4 +92,9 @@
     <string name="po_cancel_payment_confirmation_confirm">إلغاء الدفع</string>
     <string name="po_cancel_payment_confirmation_dismiss">ليس الآن</string>
 
+    <!-- Cancel Confirmation -->
+    <string name="po_cancel_confirmation_title">إلغاء؟</string>
+    <string name="po_cancel_confirmation_confirm">إلغاء</string>
+    <string name="po_cancel_confirmation_dismiss">ليس الآن</string>
+
 </resources>

--- a/sdk/src/main/res/values-fr/strings.xml
+++ b/sdk/src/main/res/values-fr/strings.xml
@@ -90,4 +90,9 @@
     <string name="po_cancel_payment_confirmation_confirm">Annuler le paiement</string>
     <string name="po_cancel_payment_confirmation_dismiss">Pas maintenant</string>
 
+    <!-- Cancel Confirmation -->
+    <string name="po_cancel_confirmation_title">Annuler ?</string>
+    <string name="po_cancel_confirmation_confirm">Annuler</string>
+    <string name="po_cancel_confirmation_dismiss">Pas maintenant</string>
+
 </resources>

--- a/sdk/src/main/res/values-pl/strings.xml
+++ b/sdk/src/main/res/values-pl/strings.xml
@@ -91,4 +91,9 @@
     <string name="po_cancel_payment_confirmation_confirm">Anuluj płatność</string>
     <string name="po_cancel_payment_confirmation_dismiss">Nie teraz</string>
 
+    <!-- Cancel Confirmation -->
+    <string name="po_cancel_confirmation_title">Anulować?</string>
+    <string name="po_cancel_confirmation_confirm">Anuluj</string>
+    <string name="po_cancel_confirmation_dismiss">Nie teraz</string>
+
 </resources>

--- a/sdk/src/main/res/values-pt/strings.xml
+++ b/sdk/src/main/res/values-pt/strings.xml
@@ -90,4 +90,9 @@
     <string name="po_cancel_payment_confirmation_confirm">Cancelar pagamento</string>
     <string name="po_cancel_payment_confirmation_dismiss">Agora não</string>
 
+    <!-- Cancel Confirmation -->
+    <string name="po_cancel_confirmation_title">Cancelar?</string>
+    <string name="po_cancel_confirmation_confirm">Cancelar</string>
+    <string name="po_cancel_confirmation_dismiss">Agora não</string>
+
 </resources>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -89,4 +89,9 @@
     <string name="po_cancel_payment_confirmation_confirm">Cancel payment</string>
     <string name="po_cancel_payment_confirmation_dismiss">Not now</string>
 
+    <!-- Cancel Confirmation -->
+    <string name="po_cancel_confirmation_title">Cancel?</string>
+    <string name="po_cancel_confirmation_confirm">Cancel</string>
+    <string name="po_cancel_confirmation_dismiss">Not now</string>
+
 </resources>

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/POActionsContainer.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/POActionsContainer.kt
@@ -109,7 +109,8 @@ private fun Actions(
                 modifier = modifier.fillMaxWidth(),
                 style = if (primary) primaryActionStyle else secondaryActionStyle,
                 enabled = enabled,
-                loading = loading
+                loading = loading,
+                iconResId = iconResId
             )
             if (requestConfirmation) {
                 confirmation?.run {

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/POButton.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/POButton.kt
@@ -25,6 +25,7 @@ import com.processout.sdk.ui.core.component.POButton.border
 import com.processout.sdk.ui.core.component.POButton.colors
 import com.processout.sdk.ui.core.component.POButton.contentPadding
 import com.processout.sdk.ui.core.component.POButton.elevation
+import com.processout.sdk.ui.core.extension.conditional
 import com.processout.sdk.ui.core.style.POButtonDefaults
 import com.processout.sdk.ui.core.style.POButtonStateStyle
 import com.processout.sdk.ui.core.style.POButtonStyle
@@ -78,7 +79,9 @@ fun POButton(
                         painter = painterResource(it),
                         contentDescription = null,
                         modifier = Modifier
-                            .padding(end = spacing.small)
+                            .conditional(text.isNotBlank()) {
+                                padding(end = spacing.small)
+                            }
                             .requiredSize(20.dp),
                         colorFilter = ColorFilter.tint(color = iconColor)
                     )

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/POButton.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/POButton.kt
@@ -1,6 +1,8 @@
 package com.processout.sdk.ui.core.component
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
@@ -10,8 +12,10 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -25,6 +29,7 @@ import com.processout.sdk.ui.core.style.POButtonDefaults
 import com.processout.sdk.ui.core.style.POButtonStateStyle
 import com.processout.sdk.ui.core.style.POButtonStyle
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
+import com.processout.sdk.ui.core.theme.ProcessOutTheme.spacing
 
 /** @suppress */
 @ProcessOutInternalApi
@@ -37,9 +42,11 @@ fun POButton(
     enabled: Boolean = true,
     loading: Boolean = false,
     leadingContent: @Composable RowScope.() -> Unit = {},
+    @DrawableRes iconResId: Int? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
 ) {
     val pressed by interactionSource.collectIsPressedAsState()
+    val colors = colors(style = style, enabled = enabled, loading = loading, pressed = pressed)
     CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides Dp.Unspecified) {
         Button(
             onClick = onClick,
@@ -47,7 +54,7 @@ fun POButton(
                 min = ProcessOutTheme.dimensions.interactiveComponentMinSize
             ),
             enabled = enabled && !loading,
-            colors = colors(style = style, enabled = enabled, loading = loading, pressed = pressed),
+            colors = colors,
             shape = if (enabled) style.normal.shape else style.disabled.shape,
             border = border(style = style, enabled = enabled, pressed = pressed),
             elevation = elevation(style = style, enabled = enabled, loading = loading),
@@ -65,6 +72,17 @@ fun POButton(
                 }
             } else {
                 leadingContent()
+                iconResId?.let {
+                    val iconColor = if (enabled) colors.contentColor else colors.disabledContentColor
+                    Image(
+                        painter = painterResource(it),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .padding(end = spacing.small)
+                            .requiredSize(20.dp),
+                        colorFilter = ColorFilter.tint(color = iconColor)
+                    )
+                }
                 POText(
                     text = text,
                     style = if (enabled) style.normal.text.textStyle else style.disabled.text.textStyle,

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/state/POActionState.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/state/POActionState.kt
@@ -1,5 +1,6 @@
 package com.processout.sdk.ui.core.state
 
+import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Immutable
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 
@@ -12,6 +13,7 @@ data class POActionState(
     val primary: Boolean,
     val enabled: Boolean = true,
     val loading: Boolean = false,
+    @DrawableRes val iconResId: Int? = null,
     val confirmation: Confirmation? = null
 ) {
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationBottomSheet.kt
@@ -23,6 +23,7 @@ import com.processout.sdk.ui.card.tokenization.CardTokenizationActivityContract.
 import com.processout.sdk.ui.card.tokenization.CardTokenizationCompletion.Failure
 import com.processout.sdk.ui.card.tokenization.CardTokenizationCompletion.Success
 import com.processout.sdk.ui.card.tokenization.CardTokenizationEvent.Dismiss
+import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration.SubmitButton
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
 import com.processout.sdk.ui.shared.component.displayCutoutHeight
 import com.processout.sdk.ui.shared.component.screenModeAsState
@@ -41,7 +42,7 @@ internal class CardTokenizationBottomSheet : BaseBottomSheetDialogFragment<POCar
     private val viewModel: CardTokenizationViewModel by viewModels {
         CardTokenizationViewModel.Factory(
             app = requireActivity().application,
-            configuration = configuration ?: POCardTokenizationConfiguration(),
+            configuration = configuration ?: POCardTokenizationConfiguration(submitButton = SubmitButton()),
             eventDispatcher = PODefaultEventDispatchers.defaultCardTokenization
         )
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
@@ -91,17 +91,21 @@ internal class CardTokenizationViewModel private constructor(
             focusedFieldId = state.focusedFieldId,
             primaryAction = POActionState(
                 id = state.primaryActionId,
-                text = primaryActionText ?: app.getString(R.string.po_card_tokenization_button_submit),
+                text = submitButton.text ?: app.getString(R.string.po_card_tokenization_button_submit),
                 primary = true,
                 enabled = state.submitAllowed,
-                loading = state.submitting
+                loading = state.submitting,
+                iconResId = submitButton.iconResId
             ),
-            secondaryAction = if (cancellation.secondaryAction) POActionState(
-                id = state.secondaryActionId,
-                text = secondaryActionText ?: app.getString(R.string.po_card_tokenization_button_cancel),
-                primary = false,
-                enabled = !state.submitting
-            ) else null,
+            secondaryAction = cancelButton?.let {
+                POActionState(
+                    id = state.secondaryActionId,
+                    text = it.text ?: app.getString(R.string.po_card_tokenization_button_cancel),
+                    primary = false,
+                    enabled = !state.submitting,
+                    iconResId = it.iconResId
+                )
+            },
             draggable = cancellation.dragDown
         )
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
@@ -16,6 +16,7 @@ import com.processout.sdk.api.dispatcher.card.tokenization.PODefaultCardTokeniza
 import com.processout.sdk.ui.card.tokenization.CardTokenizationInteractorState.*
 import com.processout.sdk.ui.card.tokenization.CardTokenizationViewModelState.*
 import com.processout.sdk.ui.core.state.POActionState
+import com.processout.sdk.ui.core.state.POActionState.Confirmation
 import com.processout.sdk.ui.core.state.POImmutableList
 import com.processout.sdk.ui.shared.extension.map
 import com.processout.sdk.ui.shared.filter.CardExpirationInputFilter
@@ -103,7 +104,17 @@ internal class CardTokenizationViewModel private constructor(
                     text = it.text ?: app.getString(R.string.po_card_tokenization_button_cancel),
                     primary = false,
                     enabled = !state.submitting,
-                    iconResId = it.iconResId
+                    iconResId = it.iconResId,
+                    confirmation = it.confirmation?.run {
+                        Confirmation(
+                            title = title ?: app.getString(R.string.po_cancel_confirmation_title),
+                            message = message,
+                            confirmActionText = confirmActionText
+                                ?: app.getString(R.string.po_cancel_confirmation_confirm),
+                            dismissActionText = dismissActionText
+                                ?: app.getString(R.string.po_cancel_confirmation_dismiss)
+                        )
+                    }
                 )
             },
             draggable = cancellation.dragDown

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
@@ -2,9 +2,11 @@ package com.processout.sdk.ui.card.tokenization
 
 import android.os.Parcelable
 import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
 import com.processout.sdk.api.model.request.POContact
 import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration.BillingAddressConfiguration.CollectionMode
 import com.processout.sdk.ui.core.style.*
+import com.processout.sdk.ui.shared.configuration.POActionConfirmationConfiguration
 import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
 import kotlinx.parcelize.Parcelize
 
@@ -16,8 +18,8 @@ import kotlinx.parcelize.Parcelize
  * @param[isCardholderNameFieldVisible] Specifies whether the cardholder name field should be displayed. Default value is _true_.
  * @param[billingAddress] Allows to customize the collection of billing address.
  * @param[savingAllowed] Displays checkbox that allows to save the card details for future payments.
- * @param[primaryActionText] Custom primary action text (e.g. "Submit").
- * @param[secondaryActionText] Custom secondary action text (e.g. "Cancel").
+ * @param[submitButton] Submit button configuration.
+ * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
  * @param[cancellation] Specifies cancellation behaviour.
  * @param[metadata] Metadata related to the card.
  * @param[style] Allows to customize the look and feel.
@@ -29,12 +31,52 @@ data class POCardTokenizationConfiguration(
     val isCardholderNameFieldVisible: Boolean = true,
     val billingAddress: BillingAddressConfiguration = BillingAddressConfiguration(),
     val savingAllowed: Boolean = false,
-    val primaryActionText: String? = null,
-    val secondaryActionText: String? = null,
+    val submitButton: SubmitButton = SubmitButton(),
+    val cancelButton: CancelButton? = CancelButton(),
     val cancellation: POCancellationConfiguration = POCancellationConfiguration(),
     val metadata: Map<String, String>? = null,
     val style: Style? = null
 ) : Parcelable {
+
+    /**
+     * Defines card tokenization configuration.
+     *
+     * @param[title] Custom title.
+     * @param[cvcRequired] Specifies whether the card CVC should be collected. Default value is _true_.
+     * @param[isCardholderNameFieldVisible] Specifies whether the cardholder name field should be displayed. Default value is _true_.
+     * @param[billingAddress] Allows to customize the collection of billing address.
+     * @param[savingAllowed] Displays checkbox that allows to save the card details for future payments.
+     * @param[primaryActionText] Custom primary action text (e.g. "Submit").
+     * @param[secondaryActionText] Custom secondary action text (e.g. "Cancel").
+     * @param[cancellation] Specifies cancellation behaviour.
+     * @param[metadata] Metadata related to the card.
+     * @param[style] Allows to customize the look and feel.
+     */
+    @Deprecated(message = "Use alternative constructor.")
+    constructor(
+        title: String? = null,
+        cvcRequired: Boolean = true,
+        isCardholderNameFieldVisible: Boolean = true,
+        billingAddress: BillingAddressConfiguration = BillingAddressConfiguration(),
+        savingAllowed: Boolean = false,
+        primaryActionText: String? = null,
+        secondaryActionText: String? = null,
+        cancellation: POCancellationConfiguration = POCancellationConfiguration(),
+        metadata: Map<String, String>? = null,
+        style: Style? = null
+    ) : this(
+        title = title,
+        cvcRequired = cvcRequired,
+        isCardholderNameFieldVisible = isCardholderNameFieldVisible,
+        billingAddress = billingAddress,
+        savingAllowed = savingAllowed,
+        submitButton = SubmitButton(text = primaryActionText),
+        cancelButton = if (cancellation.secondaryAction)
+            CancelButton(text = secondaryActionText) else null,
+        cancellation = cancellation,
+        metadata = metadata,
+        style = style
+    )
 
     /**
      * Defines billing address configuration.
@@ -68,6 +110,35 @@ data class POCardTokenizationConfiguration(
             Full
         }
     }
+
+    /**
+     * Submit button configuration.
+     *
+     * @param[text] Button text. Pass _null_ to use default text.
+     * @param[iconResId] Button icon drawable resource ID. Pass _null_ to hide.
+     */
+    @Parcelize
+    data class SubmitButton(
+        val text: String? = null,
+        @DrawableRes
+        val iconResId: Int? = null
+    ) : Parcelable
+
+    /**
+     * Cancel button configuration.
+     *
+     * @param[text] Button text. Pass _null_ to use default text.
+     * @param[iconResId] Button icon drawable resource ID. Pass _null_ to hide.
+     * @param[confirmation] Specifies action confirmation configuration (e.g. dialog).
+     * Use _null_ to disable, this is a default behaviour.
+     */
+    @Parcelize
+    data class CancelButton(
+        val text: String? = null,
+        @DrawableRes
+        val iconResId: Int? = null,
+        val confirmation: POActionConfirmationConfiguration? = null
+    ) : Parcelable
 
     /**
      * Allows to customize the look and feel.

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateBottomSheet.kt
@@ -21,6 +21,8 @@ import com.processout.sdk.ui.base.BaseBottomSheetDialogFragment
 import com.processout.sdk.ui.card.update.CardUpdateCompletion.Failure
 import com.processout.sdk.ui.card.update.CardUpdateCompletion.Success
 import com.processout.sdk.ui.card.update.CardUpdateEvent.Dismiss
+import com.processout.sdk.ui.card.update.POCardUpdateConfiguration.Options
+import com.processout.sdk.ui.card.update.POCardUpdateConfiguration.SubmitButton
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
 import com.processout.sdk.ui.shared.component.screenModeAsState
 import com.processout.sdk.ui.shared.extension.dpToPx
@@ -40,7 +42,7 @@ internal class CardUpdateBottomSheet : BaseBottomSheetDialogFragment<POCard>() {
         CardUpdateViewModel.Factory(
             app = requireActivity().application,
             cardId = configuration?.cardId ?: String(),
-            options = configuration?.options ?: POCardUpdateConfiguration.Options()
+            options = configuration?.options ?: Options(submitButton = SubmitButton())
         )
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateViewModel.kt
@@ -28,6 +28,7 @@ import com.processout.sdk.core.onSuccess
 import com.processout.sdk.ui.card.update.CardUpdateCompletion.*
 import com.processout.sdk.ui.card.update.CardUpdateEvent.*
 import com.processout.sdk.ui.core.state.POActionState
+import com.processout.sdk.ui.core.state.POActionState.Confirmation
 import com.processout.sdk.ui.core.state.POImmutableList
 import com.processout.sdk.ui.shared.extension.orElse
 import com.processout.sdk.ui.shared.filter.CardSecurityCodeInputFilter
@@ -109,7 +110,17 @@ internal class CardUpdateViewModel private constructor(
                     id = ActionId.CANCEL,
                     text = it.text ?: app.getString(R.string.po_card_update_button_cancel),
                     primary = false,
-                    iconResId = it.iconResId
+                    iconResId = it.iconResId,
+                    confirmation = it.confirmation?.run {
+                        Confirmation(
+                            title = title ?: app.getString(R.string.po_cancel_confirmation_title),
+                            message = message,
+                            confirmActionText = confirmActionText
+                                ?: app.getString(R.string.po_cancel_confirmation_confirm),
+                            dismissActionText = dismissActionText
+                                ?: app.getString(R.string.po_cancel_confirmation_dismiss)
+                        )
+                    }
                 )
             },
             draggable = cancellation.dragDown

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateViewModel.kt
@@ -100,14 +100,18 @@ internal class CardUpdateViewModel private constructor(
             focusedFieldId = CardFieldId.CVC,
             primaryAction = POActionState(
                 id = ActionId.SUBMIT,
-                text = primaryActionText ?: app.getString(R.string.po_card_update_button_submit),
-                primary = true
+                text = submitButton.text ?: app.getString(R.string.po_card_update_button_submit),
+                primary = true,
+                iconResId = submitButton.iconResId
             ),
-            secondaryAction = if (cancellation.secondaryAction) POActionState(
-                id = ActionId.CANCEL,
-                text = secondaryActionText ?: app.getString(R.string.po_card_update_button_cancel),
-                primary = false
-            ) else null,
+            secondaryAction = cancelButton?.let {
+                POActionState(
+                    id = ActionId.CANCEL,
+                    text = it.text ?: app.getString(R.string.po_card_update_button_cancel),
+                    primary = false,
+                    iconResId = it.iconResId
+                )
+            },
             draggable = cancellation.dragDown
         )
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/POCardUpdateConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/POCardUpdateConfiguration.kt
@@ -2,9 +2,11 @@ package com.processout.sdk.ui.card.update
 
 import android.os.Parcelable
 import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
 import com.processout.sdk.ui.core.style.POActionsContainerStyle
 import com.processout.sdk.ui.core.style.POFieldStyle
 import com.processout.sdk.ui.core.style.POTextStyle
+import com.processout.sdk.ui.shared.configuration.POActionConfirmationConfiguration
 import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
 import kotlinx.parcelize.Parcelize
 
@@ -18,7 +20,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class POCardUpdateConfiguration(
     val cardId: String,
-    val options: Options = Options(),
+    val options: Options = Options(submitButton = SubmitButton()),
     val style: Style? = null
 ) : Parcelable {
 
@@ -27,17 +29,72 @@ data class POCardUpdateConfiguration(
      *
      * @param[title] Custom title.
      * @param[cardInformation] Allows to provide card information that will be visible in UI.
-     * @param[primaryActionText] Custom primary action text (e.g. "Submit").
-     * @param[secondaryActionText] Custom secondary action text (e.g. "Cancel").
+     * @param[submitButton] Submit button configuration.
+     * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
      * @param[cancellation] Specifies cancellation behaviour.
      */
     @Parcelize
     data class Options(
         val title: String? = null,
         val cardInformation: CardInformation? = null,
-        val primaryActionText: String? = null,
-        val secondaryActionText: String? = null,
+        val submitButton: SubmitButton = SubmitButton(),
+        val cancelButton: CancelButton? = CancelButton(),
         val cancellation: POCancellationConfiguration = POCancellationConfiguration()
+    ) : Parcelable {
+
+        /**
+         * Allows to customize behaviour and pre-define the values.
+         *
+         * @param[title] Custom title.
+         * @param[cardInformation] Allows to provide card information that will be visible in UI.
+         * @param[primaryActionText] Custom primary action text (e.g. "Submit").
+         * @param[secondaryActionText] Custom secondary action text (e.g. "Cancel").
+         * @param[cancellation] Specifies cancellation behaviour.
+         */
+        @Deprecated(message = "Use alternative constructor.")
+        constructor(
+            title: String? = null,
+            cardInformation: CardInformation? = null,
+            primaryActionText: String? = null,
+            secondaryActionText: String? = null,
+            cancellation: POCancellationConfiguration = POCancellationConfiguration()
+        ) : this(
+            title = title,
+            cardInformation = cardInformation,
+            submitButton = SubmitButton(text = primaryActionText),
+            cancelButton = if (cancellation.secondaryAction)
+                CancelButton(text = secondaryActionText) else null,
+            cancellation = cancellation
+        )
+    }
+
+    /**
+     * Submit button configuration.
+     *
+     * @param[text] Button text. Pass _null_ to use default text.
+     * @param[iconResId] Button icon drawable resource ID. Pass _null_ to hide.
+     */
+    @Parcelize
+    data class SubmitButton(
+        val text: String? = null,
+        @DrawableRes
+        val iconResId: Int? = null
+    ) : Parcelable
+
+    /**
+     * Cancel button configuration.
+     *
+     * @param[text] Button text. Pass _null_ to use default text.
+     * @param[iconResId] Button icon drawable resource ID. Pass _null_ to hide.
+     * @param[confirmation] Specifies action confirmation configuration (e.g. dialog).
+     * Use _null_ to disable, this is a default behaviour.
+     */
+    @Parcelize
+    data class CancelButton(
+        val text: String? = null,
+        @DrawableRes
+        val iconResId: Int? = null,
+        val confirmation: POActionConfirmationConfiguration? = null
     ) : Parcelable
 
     /**

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
@@ -47,11 +47,14 @@ import com.processout.sdk.ui.checkout.DynamicCheckoutCompletion.Success
 import com.processout.sdk.ui.checkout.DynamicCheckoutEvent.*
 import com.processout.sdk.ui.checkout.DynamicCheckoutSideEffect.*
 import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration.CancelButton
+import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration.SubmitButton
 import com.processout.sdk.ui.checkout.screen.DynamicCheckoutScreen
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
 import com.processout.sdk.ui.googlepay.POGooglePayCardTokenizationLauncher
 import com.processout.sdk.ui.napm.NativeAlternativePaymentViewModel
-import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.*
+import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration
+import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.Options
+import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.PaymentConfirmationConfiguration
 import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.PaymentConfirmationConfiguration.Companion.DEFAULT_TIMEOUT_SECONDS
 import com.processout.sdk.ui.shared.configuration.POBarcodeConfiguration
 import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
@@ -115,20 +118,15 @@ internal class DynamicCheckoutActivity : BaseTransparentPortraitActivity() {
     private fun nativeAlternativePaymentConfiguration(): Options {
         val paymentConfirmation = configuration?.alternativePayment?.paymentConfirmation
         return Options(
-            primaryActionText = configuration?.submitButton?.text,
-            secondaryAction = configuration?.cancelButton?.toSecondaryAction(),
+            submitButton = configuration?.submitButton?.map() ?: PONativeAlternativePaymentConfiguration.SubmitButton(),
+            cancelButton = configuration?.cancelButton?.map(),
             paymentConfirmation = PaymentConfirmationConfiguration(
                 waitsConfirmation = true,
                 timeoutSeconds = paymentConfirmation?.timeoutSeconds ?: DEFAULT_TIMEOUT_SECONDS,
                 showProgressIndicatorAfterSeconds = paymentConfirmation?.showProgressIndicatorAfterSeconds,
                 hideGatewayDetails = true,
-                primaryAction = paymentConfirmation?.confirmButton?.let {
-                    ConfirmAction(
-                        text = it.text,
-                        iconResId = it.iconResId
-                    )
-                },
-                secondaryAction = paymentConfirmation?.cancelButton?.toSecondaryAction()
+                confirmButton = paymentConfirmation?.confirmButton?.map(),
+                cancelButton = paymentConfirmation?.cancelButton?.map()
             ),
             barcode = configuration?.alternativePayment?.barcode
                 ?: POBarcodeConfiguration(saveButton = POBarcodeConfiguration.Button()),
@@ -137,8 +135,14 @@ internal class DynamicCheckoutActivity : BaseTransparentPortraitActivity() {
         )
     }
 
-    private fun CancelButton.toSecondaryAction() = SecondaryAction.Cancel(
+    private fun SubmitButton.map() = PONativeAlternativePaymentConfiguration.SubmitButton(
         text = text,
+        iconResId = iconResId
+    )
+
+    private fun CancelButton.map() = PONativeAlternativePaymentConfiguration.CancelButton(
+        text = text,
+        iconResId = iconResId,
         disabledForSeconds = disabledForSeconds,
         confirmation = confirmation
     )

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
@@ -122,7 +122,12 @@ internal class DynamicCheckoutActivity : BaseTransparentPortraitActivity() {
                 timeoutSeconds = paymentConfirmation?.timeoutSeconds ?: DEFAULT_TIMEOUT_SECONDS,
                 showProgressIndicatorAfterSeconds = paymentConfirmation?.showProgressIndicatorAfterSeconds,
                 hideGatewayDetails = true,
-                primaryAction = paymentConfirmation?.confirmButton?.let { ConfirmAction(text = it.text) },
+                primaryAction = paymentConfirmation?.confirmButton?.let {
+                    ConfirmAction(
+                        text = it.text,
+                        iconResId = it.iconResId
+                    )
+                },
                 secondaryAction = paymentConfirmation?.cancelButton?.toSecondaryAction()
             ),
             barcode = configuration?.alternativePayment?.barcode ?: POBarcodeConfiguration(),

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
@@ -130,7 +130,8 @@ internal class DynamicCheckoutActivity : BaseTransparentPortraitActivity() {
                 },
                 secondaryAction = paymentConfirmation?.cancelButton?.toSecondaryAction()
             ),
-            barcode = configuration?.alternativePayment?.barcode ?: POBarcodeConfiguration(),
+            barcode = configuration?.alternativePayment?.barcode
+                ?: POBarcodeConfiguration(saveButton = POBarcodeConfiguration.Button()),
             inlineSingleSelectValuesLimit = configuration?.alternativePayment?.inlineSingleSelectValuesLimit ?: 5,
             skipSuccessScreen = true
         )

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
@@ -103,7 +103,7 @@ internal class DynamicCheckoutActivity : BaseTransparentPortraitActivity() {
                 defaultAddress = billingAddress?.defaultAddress,
                 attachDefaultsToPaymentMethod = billingAddress?.attachDefaultsToPaymentMethod ?: false
             ),
-            primaryActionText = configuration?.submitButtonText,
+            primaryActionText = configuration?.submitButton?.text,
             secondaryActionText = configuration?.cancelButton?.text,
             cancellation = POCancellationConfiguration(
                 secondaryAction = configuration?.cancelButton != null
@@ -115,7 +115,7 @@ internal class DynamicCheckoutActivity : BaseTransparentPortraitActivity() {
     private fun nativeAlternativePaymentConfiguration(): Options {
         val paymentConfirmation = configuration?.alternativePayment?.paymentConfirmation
         return Options(
-            primaryActionText = configuration?.submitButtonText,
+            primaryActionText = configuration?.submitButton?.text,
             secondaryAction = configuration?.cancelButton?.toSecondaryAction(),
             paymentConfirmation = PaymentConfirmationConfiguration(
                 waitsConfirmation = true,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
@@ -225,14 +225,16 @@ internal class DynamicCheckoutActivity : BaseTransparentPortraitActivity() {
 
     private fun dispatchBackPressed() {
         onBackPressedDispatcher.addCallback(this) {
-            viewModel.onEvent(
-                Dismiss(
-                    ProcessOutResult.Failure(
-                        code = Cancelled,
-                        message = "Cancelled by the user with back press or gesture."
+            if (configuration?.cancelOnBackPressed == true) {
+                viewModel.onEvent(
+                    Dismiss(
+                        ProcessOutResult.Failure(
+                            code = Cancelled,
+                            message = "Cancelled by the user with back press or gesture."
+                        )
                     )
                 )
-            )
+            }
         }
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutActivity.kt
@@ -57,7 +57,6 @@ import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.Option
 import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.PaymentConfirmationConfiguration
 import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.PaymentConfirmationConfiguration.Companion.DEFAULT_TIMEOUT_SECONDS
 import com.processout.sdk.ui.shared.configuration.POBarcodeConfiguration
-import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
 import com.processout.sdk.ui.shared.extension.collectImmediately
 import com.processout.sdk.ui.web.customtab.POCustomTabAuthorizationActivity
 import com.processout.sdk.ui.web.customtab.POCustomTabAuthorizationActivityContract
@@ -106,11 +105,19 @@ internal class DynamicCheckoutActivity : BaseTransparentPortraitActivity() {
                 defaultAddress = billingAddress?.defaultAddress,
                 attachDefaultsToPaymentMethod = billingAddress?.attachDefaultsToPaymentMethod ?: false
             ),
-            primaryActionText = configuration?.submitButton?.text,
-            secondaryActionText = configuration?.cancelButton?.text,
-            cancellation = POCancellationConfiguration(
-                secondaryAction = configuration?.cancelButton != null
-            ),
+            submitButton = configuration?.submitButton?.let {
+                POCardTokenizationConfiguration.SubmitButton(
+                    text = it.text,
+                    iconResId = it.iconResId
+                )
+            } ?: POCardTokenizationConfiguration.SubmitButton(),
+            cancelButton = configuration?.cancelButton?.let {
+                POCardTokenizationConfiguration.CancelButton(
+                    text = it.text,
+                    iconResId = it.iconResId,
+                    confirmation = it.confirmation
+                )
+            },
             metadata = configuration?.card?.metadata
         )
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
@@ -233,7 +233,7 @@ internal class DynamicCheckoutViewModel private constructor(
         interactorState.paymentMethods.mapNotNull { paymentMethod ->
             val id = paymentMethod.id
             val selected = id == interactorState.selectedPaymentMethod?.id
-            val submitButtonText = configuration.submitButtonText ?: app.getString(R.string.po_dynamic_checkout_button_pay)
+            val submitButtonText = configuration.submitButton.text ?: app.getString(R.string.po_dynamic_checkout_button_pay)
             when (paymentMethod) {
                 is Card -> RegularPayment(
                     id = id,
@@ -243,7 +243,11 @@ internal class DynamicCheckoutViewModel private constructor(
                         selected = selected
                     ),
                     content = if (selected) Content.Card(cardTokenizationState) else null,
-                    submitAction = if (selected) cardTokenizationState.primaryAction.copy(text = submitButtonText) else null
+                    submitAction = if (selected)
+                        cardTokenizationState.primaryAction.copy(
+                            text = submitButtonText,
+                            iconResId = configuration.submitButton.iconResId
+                        ) else null
                 )
                 is AlternativePayment -> if (!paymentMethod.isExpress)
                     RegularPayment(
@@ -260,7 +264,8 @@ internal class DynamicCheckoutViewModel private constructor(
                             text = submitButtonText,
                             primary = true,
                             loading = id == interactorState.processingPaymentMethod?.id ||
-                                    interactorState.invoice == null
+                                    interactorState.invoice == null,
+                            iconResId = configuration.submitButton.iconResId
                         )
                     ) else null
                 is NativeAlternativePayment -> RegularPayment(
@@ -273,7 +278,10 @@ internal class DynamicCheckoutViewModel private constructor(
                     ),
                     content = if (selected) Content.NativeAlternativePayment(nativeAlternativePaymentState) else null,
                     submitAction = if (selected && nativeAlternativePaymentState is UserInput)
-                        nativeAlternativePaymentState.primaryAction.copy(text = submitButtonText) else null
+                        nativeAlternativePaymentState.primaryAction.copy(
+                            text = submitButtonText,
+                            iconResId = configuration.submitButton.iconResId
+                        ) else null
                 )
                 else -> null
             }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
@@ -146,7 +146,10 @@ internal class DynamicCheckoutViewModel private constructor(
                 }
             }
             else -> defaultCancelAction
-        }?.copy(id = interactorState.cancelActionId)
+        }?.copy(
+            id = interactorState.cancelActionId,
+            iconResId = configuration.cancelButton?.iconResId
+        )
     }
 
     private fun CancelButton.toActionState(

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
@@ -99,17 +99,9 @@ data class PODynamicCheckoutConfiguration(
         data class PaymentConfirmationConfiguration(
             val timeoutSeconds: Int = 3 * 60,
             val showProgressIndicatorAfterSeconds: Int? = null,
-            val confirmButton: ConfirmButton? = null,
+            val confirmButton: SubmitButton? = null,
             val cancelButton: CancelButton? = CancelButton()
-        ) : Parcelable {
-
-            @Parcelize
-            data class ConfirmButton(
-                val text: String? = null,
-                @DrawableRes
-                val iconResId: Int? = null
-            ) : Parcelable
-        }
+        ) : Parcelable
     }
 
     @Parcelize

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
@@ -91,7 +91,7 @@ data class PODynamicCheckoutConfiguration(
     data class AlternativePaymentConfiguration(
         val returnUrl: String? = null,
         val inlineSingleSelectValuesLimit: Int = 5,
-        val barcode: POBarcodeConfiguration = POBarcodeConfiguration(),
+        val barcode: POBarcodeConfiguration = POBarcodeConfiguration(saveButton = POBarcodeConfiguration.Button()),
         val paymentConfirmation: PaymentConfirmationConfiguration = PaymentConfirmationConfiguration()
     ) : Parcelable {
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
@@ -105,7 +105,9 @@ data class PODynamicCheckoutConfiguration(
 
             @Parcelize
             data class ConfirmButton(
-                val text: String? = null
+                val text: String? = null,
+                @DrawableRes
+                val iconResId: Int? = null
             ) : Parcelable
         }
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
@@ -20,9 +20,10 @@ data class PODynamicCheckoutConfiguration(
     val card: CardConfiguration = CardConfiguration(),
     val googlePay: GooglePayConfiguration = GooglePayConfiguration(),
     val alternativePayment: AlternativePaymentConfiguration = AlternativePaymentConfiguration(),
-    val preselectSinglePaymentMethod: Boolean = true,
     val submitButton: SubmitButton = SubmitButton(),
     val cancelButton: CancelButton? = CancelButton(),
+    val cancelOnBackPressed: Boolean = true,
+    val preselectSinglePaymentMethod: Boolean = true,
     val paymentSuccess: PaymentSuccess? = PaymentSuccess(),
     val style: Style? = null
 ) : Parcelable {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
@@ -120,6 +120,8 @@ data class PODynamicCheckoutConfiguration(
     @Parcelize
     data class CancelButton(
         val text: String? = null,
+        @DrawableRes
+        val iconResId: Int? = null,
         val disabledForSeconds: Int = 0,
         val confirmation: POActionConfirmationConfiguration? = null
     ) : Parcelable

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
@@ -21,7 +21,7 @@ data class PODynamicCheckoutConfiguration(
     val googlePay: GooglePayConfiguration = GooglePayConfiguration(),
     val alternativePayment: AlternativePaymentConfiguration = AlternativePaymentConfiguration(),
     val preselectSinglePaymentMethod: Boolean = true,
-    val submitButtonText: String? = null,
+    val submitButton: SubmitButton = SubmitButton(),
     val cancelButton: CancelButton? = CancelButton(),
     val paymentSuccess: PaymentSuccess? = PaymentSuccess(),
     val style: Style? = null
@@ -109,6 +109,13 @@ data class PODynamicCheckoutConfiguration(
             ) : Parcelable
         }
     }
+
+    @Parcelize
+    data class SubmitButton(
+        val text: String? = null,
+        @DrawableRes
+        val iconResId: Int? = null
+    ) : Parcelable
 
     @Parcelize
     data class CancelButton(

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/DynamicCheckoutScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/DynamicCheckoutScreen.kt
@@ -443,7 +443,8 @@ private fun RegularPaymentContent(
                             .padding(top = spacing.extraLarge),
                         style = style.actionsContainer.primary,
                         enabled = enabled,
-                        loading = loading
+                        loading = loading,
+                        iconResId = iconResId
                     )
                 }
             }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/NativeAlternativePayment.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/NativeAlternativePayment.kt
@@ -419,7 +419,8 @@ private fun Capture(
                             )
                         },
                         modifier = Modifier.fillMaxWidth(),
-                        style = style.actionsContainer.secondary
+                        style = style.actionsContainer.secondary,
+                        iconResId = action.iconResId
                     )
                 }
             }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/NativeAlternativePayment.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/NativeAlternativePayment.kt
@@ -403,7 +403,8 @@ private fun Capture(
                             )
                         },
                         modifier = Modifier.fillMaxWidth(),
-                        style = style.actionsContainer.primary
+                        style = style.actionsContainer.primary,
+                        iconResId = action.iconResId
                     )
                 }
                 state.saveBarcodeAction?.let { action ->

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentBottomSheet.kt
@@ -29,6 +29,7 @@ import com.processout.sdk.ui.napm.NativeAlternativePaymentScreen.AnimationDurati
 import com.processout.sdk.ui.napm.NativeAlternativePaymentSideEffect.PermissionRequest
 import com.processout.sdk.ui.napm.NativeAlternativePaymentViewModelState.Capture
 import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.Options
+import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.SubmitButton
 import com.processout.sdk.ui.shared.component.isImeVisibleAsState
 import com.processout.sdk.ui.shared.component.screenModeAsState
 import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
@@ -54,7 +55,7 @@ internal class NativeAlternativePaymentBottomSheet : BaseBottomSheetDialogFragme
             app = requireActivity().application,
             invoiceId = configuration?.invoiceId ?: String(),
             gatewayConfigurationId = configuration?.gatewayConfigurationId ?: String(),
-            options = configuration?.options ?: Options(),
+            options = configuration?.options ?: Options(submitButton = SubmitButton()),
             eventDispatcher = PODefaultEventDispatchers.defaultNativeAlternativePaymentMethod
         )
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentBottomSheet.kt
@@ -32,7 +32,6 @@ import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.Option
 import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.SubmitButton
 import com.processout.sdk.ui.shared.component.isImeVisibleAsState
 import com.processout.sdk.ui.shared.component.screenModeAsState
-import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
 import com.processout.sdk.ui.shared.extension.collectImmediately
 import com.processout.sdk.ui.shared.extension.dpToPx
 import kotlinx.coroutines.delay
@@ -133,15 +132,7 @@ internal class NativeAlternativePaymentBottomSheet : BaseBottomSheetDialogFragme
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        configuration?.options?.cancellation?.let {
-            apply(
-                POCancellationConfiguration(
-                    backPressed = it.backPressed,
-                    dragDown = it.dragDown,
-                    touchOutside = it.touchOutside
-                )
-            )
-        }
+        configuration?.let { apply(it.options.cancellation) }
     }
 
     private fun handle(sideEffect: NativeAlternativePaymentSideEffect) {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
@@ -45,9 +45,8 @@ import com.processout.sdk.ui.napm.NativeAlternativePaymentEvent.*
 import com.processout.sdk.ui.napm.NativeAlternativePaymentEvent.Action
 import com.processout.sdk.ui.napm.NativeAlternativePaymentInteractorState.*
 import com.processout.sdk.ui.napm.NativeAlternativePaymentSideEffect.PermissionRequest
+import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.CancelButton
 import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.Options
-import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.SecondaryAction
-import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.SecondaryAction.Cancel
 import com.processout.sdk.ui.shared.extension.dpToPx
 import com.processout.sdk.ui.shared.provider.BarcodeBitmapProvider
 import com.processout.sdk.ui.shared.provider.MediaStorageProvider
@@ -714,7 +713,7 @@ internal class NativeAlternativePaymentInteractor(
         dispatch(WillWaitForCaptureConfirmation(additionalActionExpected = additionalActionExpected))
         _state.update { Capturing(captureStateValue) }
         enableCapturingSecondaryAction()
-        if (!additionalActionExpected || options.paymentConfirmation.primaryAction == null) {
+        if (!additionalActionExpected || options.paymentConfirmation.confirmButton == null) {
             capture()
         }
     }
@@ -829,14 +828,11 @@ internal class NativeAlternativePaymentInteractor(
 
     //region Features
 
-    private val SecondaryAction?.disabledForMillis: Long
-        get() = when (this) {
-            is Cancel -> disabledForSeconds * 1000L
-            null -> 0
-        }
+    private val CancelButton?.disabledForMillis: Long
+        get() = this?.disabledForSeconds?.let { it * 1000L } ?: 0
 
     private fun enableUserInputSecondaryAction() {
-        handler.postDelayed(delayInMillis = options.secondaryAction.disabledForMillis) {
+        handler.postDelayed(delayInMillis = options.cancelButton.disabledForMillis) {
             _state.whenUserInput { stateValue ->
                 _state.update {
                     with(stateValue) {
@@ -848,7 +844,7 @@ internal class NativeAlternativePaymentInteractor(
     }
 
     private fun enableCapturingSecondaryAction() {
-        handler.postDelayed(delayInMillis = options.paymentConfirmation.secondaryAction.disabledForMillis) {
+        handler.postDelayed(delayInMillis = options.paymentConfirmation.cancelButton.disabledForMillis) {
             _state.whenCapturing { stateValue ->
                 _state.update {
                     with(stateValue) {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModel.kt
@@ -22,11 +22,10 @@ import com.processout.sdk.ui.core.state.POImmutableList
 import com.processout.sdk.ui.napm.NativeAlternativePaymentInteractorState.*
 import com.processout.sdk.ui.napm.NativeAlternativePaymentViewModelState.Field.*
 import com.processout.sdk.ui.napm.NativeAlternativePaymentViewModelState.Image
+import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.CancelButton
 import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.Options
 import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.PaymentConfirmationConfiguration.Companion.DEFAULT_TIMEOUT_SECONDS
 import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.PaymentConfirmationConfiguration.Companion.MAX_TIMEOUT_SECONDS
-import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.SecondaryAction
-import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.SecondaryAction.Cancel
 import com.processout.sdk.ui.shared.extension.map
 import com.processout.sdk.ui.shared.filter.PhoneNumberInputFilter
 import com.processout.sdk.ui.shared.provider.BarcodeBitmapProvider
@@ -139,12 +138,13 @@ internal class NativeAlternativePaymentViewModel private constructor(
             focusedFieldId = focusedFieldId,
             primaryAction = POActionState(
                 id = primaryActionId,
-                text = options.primaryActionText ?: invoice.formatPrimaryActionText(),
+                text = options.submitButton.text ?: invoice.formatPrimaryActionText(),
                 primary = true,
                 enabled = submitAllowed,
-                loading = submitting
+                loading = submitting,
+                iconResId = options.submitButton.iconResId
             ),
-            secondaryAction = options.secondaryAction?.toActionState(
+            secondaryAction = options.cancelButton?.toActionState(
                 id = secondaryAction.id,
                 enabled = secondaryAction.enabled && !submitting
             )
@@ -152,7 +152,7 @@ internal class NativeAlternativePaymentViewModel private constructor(
     }
 
     private fun Capturing.map() = with(value) {
-        val secondaryAction = options.paymentConfirmation.secondaryAction?.toActionState(
+        val secondaryAction = options.paymentConfirmation.cancelButton?.toActionState(
             id = secondaryAction.id,
             enabled = secondaryAction.enabled
         )
@@ -162,7 +162,7 @@ internal class NativeAlternativePaymentViewModel private constructor(
                 secondaryAction = secondaryAction
             )
         } else {
-            val primaryAction = options.paymentConfirmation.primaryAction?.let {
+            val primaryAction = options.paymentConfirmation.confirmButton?.let {
                 primaryActionId?.let { id ->
                     POActionState(
                         id = id,
@@ -361,27 +361,26 @@ internal class NativeAlternativePaymentViewModel private constructor(
             app.getString(R.string.po_native_apm_submit_button_text)
         }
 
-    private fun SecondaryAction.toActionState(
+    private fun CancelButton.toActionState(
         id: String,
         enabled: Boolean
-    ): POActionState = when (this) {
-        is Cancel -> POActionState(
-            id = id,
-            text = text ?: app.getString(R.string.po_native_apm_cancel_button_text),
-            primary = false,
-            enabled = enabled,
-            confirmation = confirmation?.run {
-                Confirmation(
-                    title = title ?: app.getString(R.string.po_cancel_payment_confirmation_title),
-                    message = message,
-                    confirmActionText = confirmActionText
-                        ?: app.getString(R.string.po_cancel_payment_confirmation_confirm),
-                    dismissActionText = dismissActionText
-                        ?: app.getString(R.string.po_cancel_payment_confirmation_dismiss)
-                )
-            }
-        )
-    }
+    ) = POActionState(
+        id = id,
+        text = text ?: app.getString(R.string.po_native_apm_cancel_button_text),
+        primary = false,
+        enabled = enabled,
+        iconResId = iconResId,
+        confirmation = confirmation?.run {
+            Confirmation(
+                title = title ?: app.getString(R.string.po_cancel_payment_confirmation_title),
+                message = message,
+                confirmActionText = confirmActionText
+                    ?: app.getString(R.string.po_cancel_payment_confirmation_confirm),
+                dismissActionText = dismissActionText
+                    ?: app.getString(R.string.po_cancel_payment_confirmation_dismiss)
+            )
+        }
+    )
 
     private fun CaptureStateValue.confirmationDialog(): ConfirmationDialogState? =
         customerAction?.barcode?.let { barcode ->

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModel.kt
@@ -167,7 +167,8 @@ internal class NativeAlternativePaymentViewModel private constructor(
                     POActionState(
                         id = id,
                         text = it.text ?: app.getString(R.string.po_native_apm_confirm_payment_button_text),
-                        primary = true
+                        primary = true,
+                        iconResId = it.iconResId
                     )
                 }
             }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentViewModel.kt
@@ -183,12 +183,13 @@ internal class NativeAlternativePaymentViewModel private constructor(
                 saveBarcodeAction = customerAction?.barcode?.let {
                     POActionState(
                         id = it.actionId,
-                        text = options.barcode.saveActionText
+                        text = options.barcode.saveButton.text
                             ?: app.getString(
                                 R.string.po_native_apm_save_barcode_button_text_format,
                                 it.type.rawType.uppercase()
                             ),
-                        primary = false
+                        primary = false,
+                        iconResId = options.barcode.saveButton.iconResId
                     )
                 },
                 confirmationDialog = confirmationDialog(),

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentConfiguration.kt
@@ -56,10 +56,13 @@ data class PONativeAlternativePaymentConfiguration(
      * Action for confirmation.
      *
      * @param[text] Action text. Pass _null_ to use default text.
+     * @param[iconResId] Action icon drawable resource ID. Pass _null_ to hide.
      */
     @Parcelize
     data class ConfirmAction(
-        val text: String? = null
+        val text: String? = null,
+        @DrawableRes
+        val iconResId: Int? = null
     ) : Parcelable
 
     /**

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentConfiguration.kt
@@ -8,6 +8,7 @@ import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.Cancel
 import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.SecondaryAction
 import com.processout.sdk.ui.shared.configuration.POActionConfirmationConfiguration
 import com.processout.sdk.ui.shared.configuration.POBarcodeConfiguration
+import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -46,7 +47,7 @@ data class PONativeAlternativePaymentConfiguration(
         val title: String? = null,
         val submitButton: SubmitButton = SubmitButton(),
         val cancelButton: CancelButton? = null,
-        val cancellation: CancellationConfiguration = CancellationConfiguration(),
+        val cancellation: POCancellationConfiguration = POCancellationConfiguration(),
         val paymentConfirmation: PaymentConfirmationConfiguration = PaymentConfirmationConfiguration(confirmButton = null),
         val barcode: POBarcodeConfiguration = POBarcodeConfiguration(saveButton = POBarcodeConfiguration.Button()),
         val inlineSingleSelectValuesLimit: Int = 5,
@@ -84,7 +85,13 @@ data class PONativeAlternativePaymentConfiguration(
             title = title,
             submitButton = SubmitButton(text = primaryActionText),
             cancelButton = secondaryAction?.toCancelButton(),
-            cancellation = cancellation,
+            cancellation = with(cancellation) {
+                POCancellationConfiguration(
+                    backPressed = backPressed,
+                    dragDown = dragDown,
+                    touchOutside = touchOutside
+                )
+            },
             paymentConfirmation = paymentConfirmation,
             barcode = barcode,
             inlineSingleSelectValuesLimit = inlineSingleSelectValuesLimit,
@@ -167,6 +174,7 @@ data class PONativeAlternativePaymentConfiguration(
      * @param[touchOutside] Cancel on touch of the outside dimmed area of the bottom sheet. Default value is _true_.
      */
     @Parcelize
+    @Deprecated(message = "Use 'POCancellationConfiguration' instead.")
     data class CancellationConfiguration(
         val backPressed: Boolean = true,
         val dragDown: Boolean = true,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentConfiguration.kt
@@ -30,8 +30,6 @@ data class PONativeAlternativePaymentConfiguration(
      * Allows to customize behaviour and pre-define the values.
      *
      * @param[title] Custom title.
-     * @param[primaryActionText] Custom primary action text (e.g. "Pay").
-     * @param[secondaryAction] Secondary action (e.g. "Cancel"). Use _null_ to hide, this is a default behaviour.
      * @param[submitButton] Submit button configuration.
      * @param[cancelButton] Cancel button configuration. Use _null_ to hide, this is a default behaviour.
      * @param[cancellation] Specifies cancellation behaviour.
@@ -44,12 +42,8 @@ data class PONativeAlternativePaymentConfiguration(
      * @param[successMessage] Custom success message when payment is completed.
      */
     @Parcelize
-    data class Options internal constructor(
+    data class Options(
         val title: String? = null,
-        @Deprecated(message = "Use 'submitButton.text' instead.")
-        val primaryActionText: String? = null,
-        @Deprecated(message = "Use 'cancelButton' instead.")
-        val secondaryAction: SecondaryAction? = null,
         val submitButton: SubmitButton = SubmitButton(),
         val cancelButton: CancelButton? = null,
         val cancellation: CancellationConfiguration = CancellationConfiguration(),
@@ -60,6 +54,21 @@ data class PONativeAlternativePaymentConfiguration(
         val successMessage: String? = null
     ) : Parcelable {
 
+        /**
+         * Allows to customize behaviour and pre-define the values.
+         *
+         * @param[title] Custom title.
+         * @param[primaryActionText] Custom primary action text (e.g. "Pay").
+         * @param[secondaryAction] Secondary action (e.g. "Cancel"). Use _null_ to hide, this is a default behaviour.
+         * @param[cancellation] Specifies cancellation behaviour.
+         * @param[paymentConfirmation] Specifies payment confirmation behaviour.
+         * @param[barcode] Specifies barcode configuration.
+         * @param[inlineSingleSelectValuesLimit] Defines maximum number of options that will be
+         * displayed inline for parameters where user should select single option (e.g. radio buttons).
+         * Default value is _5_.
+         * @param[skipSuccessScreen] Only applies when [PaymentConfirmationConfiguration.waitsConfirmation] is _true_.
+         * @param[successMessage] Custom success message when payment is completed.
+         */
         @Deprecated(message = "Use alternative constructor.")
         constructor(
             title: String? = null,
@@ -73,34 +82,8 @@ data class PONativeAlternativePaymentConfiguration(
             successMessage: String? = null
         ) : this(
             title = title,
-            primaryActionText = primaryActionText,
-            secondaryAction = secondaryAction,
             submitButton = SubmitButton(text = primaryActionText),
             cancelButton = secondaryAction?.toCancelButton(),
-            cancellation = cancellation,
-            paymentConfirmation = paymentConfirmation,
-            barcode = barcode,
-            inlineSingleSelectValuesLimit = inlineSingleSelectValuesLimit,
-            skipSuccessScreen = skipSuccessScreen,
-            successMessage = successMessage
-        )
-
-        constructor(
-            title: String? = null,
-            submitButton: SubmitButton = SubmitButton(),
-            cancelButton: CancelButton? = null,
-            cancellation: CancellationConfiguration = CancellationConfiguration(),
-            paymentConfirmation: PaymentConfirmationConfiguration = PaymentConfirmationConfiguration(confirmButton = null),
-            barcode: POBarcodeConfiguration = POBarcodeConfiguration(saveButton = POBarcodeConfiguration.Button()),
-            inlineSingleSelectValuesLimit: Int = 5,
-            skipSuccessScreen: Boolean = false,
-            successMessage: String? = null
-        ) : this(
-            title = title,
-            primaryActionText = submitButton.text,
-            secondaryAction = cancelButton?.toSecondaryAction(),
-            submitButton = submitButton,
-            cancelButton = cancelButton,
             cancellation = cancellation,
             paymentConfirmation = paymentConfirmation,
             barcode = barcode,
@@ -143,17 +126,14 @@ data class PONativeAlternativePaymentConfiguration(
     ) : Parcelable
 
     /**
-     * Action for confirmation.
+     * Confirmation action.
      *
      * @param[text] Action text. Pass _null_ to use default text.
-     * @param[iconResId] Action icon drawable resource ID. Pass _null_ to hide.
      */
     @Parcelize
     @Deprecated(message = "Use 'SubmitButton' instead.")
     data class ConfirmAction(
-        val text: String? = null,
-        @DrawableRes
-        val iconResId: Int? = null
+        val text: String? = null
     ) : Parcelable
 
     /**
@@ -204,23 +184,15 @@ data class PONativeAlternativePaymentConfiguration(
      * Use _null_ to hide, this is a default behaviour.
      * @param[hideGatewayDetails] Specifies whether gateway information (such as name/logo) should be hidden during payment confirmation
      * even when specific payment provider details are not available. Default value is _false_.
-     * @param[primaryAction] Optional primary action for payment confirmation.
-     * To hide action use _null_, this is a default behaviour.
-     * @param[secondaryAction] Secondary action (e.g. "Cancel") that could be optionally presented to user during payment confirmation stage.
-     * Use _null_ to hide, this is a default behaviour.
      * @param[confirmButton] Confirm button configuration.
      * @param[cancelButton] Cancel button configuration.
      */
     @Parcelize
-    data class PaymentConfirmationConfiguration internal constructor(
+    data class PaymentConfirmationConfiguration(
         val waitsConfirmation: Boolean = true,
         val timeoutSeconds: Int = DEFAULT_TIMEOUT_SECONDS,
         val showProgressIndicatorAfterSeconds: Int? = null,
         val hideGatewayDetails: Boolean = false,
-        @Deprecated(message = "Use 'confirmButton' instead.")
-        val primaryAction: ConfirmAction? = null,
-        @Deprecated(message = "Use 'cancelButton' instead.")
-        val secondaryAction: SecondaryAction? = null,
         val confirmButton: SubmitButton? = null,
         val cancelButton: CancelButton? = null
     ) : Parcelable {
@@ -230,6 +202,22 @@ data class PONativeAlternativePaymentConfiguration(
             const val DEFAULT_TIMEOUT_SECONDS = 3 * 60
         }
 
+        /**
+         * Specifies payment confirmation behaviour.
+         *
+         * @param[waitsConfirmation] Specifies whether flow should wait for payment confirmation from PSP
+         * or will complete right after all user input is submitted. Default value is _true_.
+         * @param[timeoutSeconds] Amount of time (in seconds) to wait for final payment confirmation.
+         * Default value is 3 minutes, while maximum value is 15 minutes.
+         * @param[showProgressIndicatorAfterSeconds] Show progress indicator during payment confirmation after provided delay (in seconds).
+         * Use _null_ to hide, this is a default behaviour.
+         * @param[hideGatewayDetails] Specifies whether gateway information (such as name/logo) should be hidden during payment confirmation
+         * even when specific payment provider details are not available. Default value is _false_.
+         * @param[primaryAction] Optional primary action for payment confirmation.
+         * To hide action use _null_, this is a default behaviour.
+         * @param[secondaryAction] Secondary action (e.g. "Cancel") that could be optionally presented to user during payment confirmation stage.
+         * Use _null_ to hide, this is a default behaviour.
+         */
         @Deprecated(message = "Use alternative constructor.")
         constructor(
             waitsConfirmation: Boolean = true,
@@ -243,32 +231,8 @@ data class PONativeAlternativePaymentConfiguration(
             timeoutSeconds = timeoutSeconds,
             showProgressIndicatorAfterSeconds = showProgressIndicatorAfterSeconds,
             hideGatewayDetails = hideGatewayDetails,
-            primaryAction = primaryAction,
-            secondaryAction = secondaryAction,
-            confirmButton = primaryAction?.let {
-                SubmitButton(text = it.text, iconResId = it.iconResId)
-            },
+            confirmButton = primaryAction?.let { SubmitButton(text = it.text) },
             cancelButton = secondaryAction?.toCancelButton()
-        )
-
-        constructor(
-            waitsConfirmation: Boolean = true,
-            timeoutSeconds: Int = DEFAULT_TIMEOUT_SECONDS,
-            showProgressIndicatorAfterSeconds: Int? = null,
-            hideGatewayDetails: Boolean = false,
-            confirmButton: SubmitButton? = null,
-            cancelButton: CancelButton? = null
-        ) : this(
-            waitsConfirmation = waitsConfirmation,
-            timeoutSeconds = timeoutSeconds,
-            showProgressIndicatorAfterSeconds = showProgressIndicatorAfterSeconds,
-            hideGatewayDetails = hideGatewayDetails,
-            primaryAction = confirmButton?.let {
-                ConfirmAction(text = it.text, iconResId = it.iconResId)
-            },
-            secondaryAction = cancelButton?.toSecondaryAction(),
-            confirmButton = confirmButton,
-            cancelButton = cancelButton
         )
     }
 
@@ -328,10 +292,3 @@ private fun SecondaryAction.toCancelButton(): CancelButton =
             confirmation = confirmation
         )
     }
-
-private fun CancelButton.toSecondaryAction() =
-    SecondaryAction.Cancel(
-        text = text,
-        disabledForSeconds = disabledForSeconds,
-        confirmation = confirmation
-    )

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentConfiguration.kt
@@ -46,7 +46,7 @@ data class PONativeAlternativePaymentConfiguration(
         val secondaryAction: SecondaryAction? = null,
         val cancellation: CancellationConfiguration = CancellationConfiguration(),
         val paymentConfirmation: PaymentConfirmationConfiguration = PaymentConfirmationConfiguration(),
-        val barcode: POBarcodeConfiguration = POBarcodeConfiguration(),
+        val barcode: POBarcodeConfiguration = POBarcodeConfiguration(saveButton = POBarcodeConfiguration.Button()),
         val inlineSingleSelectValuesLimit: Int = 5,
         val skipSuccessScreen: Boolean = false,
         val successMessage: String? = null

--- a/ui/src/main/kotlin/com/processout/sdk/ui/shared/configuration/POBarcodeConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/shared/configuration/POBarcodeConfiguration.kt
@@ -1,16 +1,54 @@
 package com.processout.sdk.ui.shared.configuration
 
 import android.os.Parcelable
+import androidx.annotation.DrawableRes
+import com.processout.sdk.core.annotation.ProcessOutInternalApi
 import kotlinx.parcelize.Parcelize
 
 /**
  * Specifies barcode configuration.
  *
- * @param[saveActionText] Text on the button that saves barcode.
- * @param[saveErrorConfirmation] Requests user confirmation (e.g. dialog) when saving barcode has failed. Use _null_ to disable.
+ * @param[saveActionText] Text on the save button.
+ * @param[saveButton] Save button configuration.
+ * @param[saveErrorConfirmation] Requests user confirmation (e.g. dialog) when barcode saving has failed. Use _null_ to disable.
  */
 @Parcelize
-data class POBarcodeConfiguration(
+data class POBarcodeConfiguration @ProcessOutInternalApi constructor(
+    @Deprecated(message = "Use 'saveButton.text' property.")
     val saveActionText: String? = null,
+    val saveButton: Button = Button(),
     val saveErrorConfirmation: POActionConfirmationConfiguration? = POActionConfirmationConfiguration()
-) : Parcelable
+) : Parcelable {
+
+    @Deprecated(message = "Use constructor POBarcodeConfiguration(saveButton, saveErrorConfirmation)")
+    constructor(
+        saveActionText: String? = null,
+        saveErrorConfirmation: POActionConfirmationConfiguration? = POActionConfirmationConfiguration()
+    ) : this(
+        saveActionText = saveActionText,
+        saveButton = Button(text = saveActionText),
+        saveErrorConfirmation = saveErrorConfirmation
+    )
+
+    constructor(
+        saveButton: Button = Button(),
+        saveErrorConfirmation: POActionConfirmationConfiguration? = POActionConfirmationConfiguration()
+    ) : this(
+        saveActionText = saveButton.text,
+        saveButton = saveButton,
+        saveErrorConfirmation = saveErrorConfirmation
+    )
+
+    /**
+     * Button configuration.
+     *
+     * @param[text] Button text. Pass _null_ to use default text.
+     * @param[iconResId] Button icon drawable resource ID. Pass _null_ to hide.
+     */
+    @Parcelize
+    data class Button(
+        val text: String? = null,
+        @DrawableRes
+        val iconResId: Int? = null
+    ) : Parcelable
+}

--- a/ui/src/main/kotlin/com/processout/sdk/ui/shared/configuration/POBarcodeConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/shared/configuration/POBarcodeConfiguration.kt
@@ -2,7 +2,6 @@ package com.processout.sdk.ui.shared.configuration
 
 import android.os.Parcelable
 import androidx.annotation.DrawableRes
-import com.processout.sdk.core.annotation.ProcessOutInternalApi
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -13,14 +12,14 @@ import kotlinx.parcelize.Parcelize
  * @param[saveErrorConfirmation] Requests user confirmation (e.g. dialog) when barcode saving has failed. Use _null_ to disable.
  */
 @Parcelize
-data class POBarcodeConfiguration @ProcessOutInternalApi constructor(
-    @Deprecated(message = "Use 'saveButton.text' property.")
+data class POBarcodeConfiguration internal constructor(
+    @Deprecated(message = "Use 'saveButton.text' instead.")
     val saveActionText: String? = null,
     val saveButton: Button = Button(),
     val saveErrorConfirmation: POActionConfirmationConfiguration? = POActionConfirmationConfiguration()
 ) : Parcelable {
 
-    @Deprecated(message = "Use constructor POBarcodeConfiguration(saveButton, saveErrorConfirmation)")
+    @Deprecated(message = "Use alternative constructor.")
     constructor(
         saveActionText: String? = null,
         saveErrorConfirmation: POActionConfirmationConfiguration? = POActionConfirmationConfiguration()

--- a/ui/src/main/kotlin/com/processout/sdk/ui/shared/configuration/POBarcodeConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/shared/configuration/POBarcodeConfiguration.kt
@@ -7,34 +7,27 @@ import kotlinx.parcelize.Parcelize
 /**
  * Specifies barcode configuration.
  *
- * @param[saveActionText] Text on the save button.
  * @param[saveButton] Save button configuration.
  * @param[saveErrorConfirmation] Requests user confirmation (e.g. dialog) when barcode saving has failed. Use _null_ to disable.
  */
 @Parcelize
-data class POBarcodeConfiguration internal constructor(
-    @Deprecated(message = "Use 'saveButton.text' instead.")
-    val saveActionText: String? = null,
+data class POBarcodeConfiguration(
     val saveButton: Button = Button(),
     val saveErrorConfirmation: POActionConfirmationConfiguration? = POActionConfirmationConfiguration()
 ) : Parcelable {
 
+    /**
+     * Specifies barcode configuration.
+     *
+     * @param[saveActionText] Save button text.
+     * @param[saveErrorConfirmation] Requests user confirmation (e.g. dialog) when barcode saving has failed. Use _null_ to disable.
+     */
     @Deprecated(message = "Use alternative constructor.")
     constructor(
         saveActionText: String? = null,
         saveErrorConfirmation: POActionConfirmationConfiguration? = POActionConfirmationConfiguration()
     ) : this(
-        saveActionText = saveActionText,
         saveButton = Button(text = saveActionText),
-        saveErrorConfirmation = saveErrorConfirmation
-    )
-
-    constructor(
-        saveButton: Button = Button(),
-        saveErrorConfirmation: POActionConfirmationConfiguration? = POActionConfirmationConfiguration()
-    ) : this(
-        saveActionText = saveButton.text,
-        saveButton = saveButton,
         saveErrorConfirmation = saveErrorConfirmation
     )
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/shared/configuration/POCancellationConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/shared/configuration/POCancellationConfiguration.kt
@@ -12,9 +12,29 @@ import kotlinx.parcelize.Parcelize
  * @param[touchOutside] Cancel on touch of the outside dimmed area of the bottom sheet. Default value is _true_.
  */
 @Parcelize
-data class POCancellationConfiguration(
+data class POCancellationConfiguration @Deprecated(message = "Use alternative constructor.") constructor(
+    @Deprecated(message = "Use configuration of specific button.")
     val secondaryAction: Boolean = true,
     val backPressed: Boolean = true,
     val dragDown: Boolean = true,
     val touchOutside: Boolean = true
-) : Parcelable
+) : Parcelable {
+
+    /**
+     * Specifies cancellation behaviour.
+     *
+     * @param[backPressed] Cancel on back button press or back gesture. Default value is _true_.
+     * @param[dragDown] Cancel when bottom sheet is dragged down out of the screen. Default value is _true_.
+     * @param[touchOutside] Cancel on touch of the outside dimmed area of the bottom sheet. Default value is _true_.
+     */
+    constructor(
+        backPressed: Boolean = true,
+        dragDown: Boolean = true,
+        touchOutside: Boolean = true
+    ) : this(
+        secondaryAction = false,
+        backPressed = backPressed,
+        dragDown = dragDown,
+        touchOutside = touchOutside
+    )
+}


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
* Added optional icon to `POButton`. Icon color always match to the text color in all states.
* Updated all screen configurations to be able to set custom icon on any button. Previous constructors deprecated.
* Added confirmation dialog to all Cancel buttons. Added strings.
* Unified `POCancellationConfiguration`, now it used on all bottom sheets. Duplicates and `secondaryAction` property is deprecated.
* Added `saveButton` to `POBarcodeConfiguration`.
* Added `cancelOnBackPressed` property to Dynamic Checkout configuration.

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-442
