### PR TITLE
feat(POM-451): (Card Tokenization) Adjustable bottom sheet height

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         kotlinVersion = '2.1.0'
         kspVersion = '2.1.0-1.0.29'
         dokkaVersion = '1.9.20'
-        androidxNavigationVersion = '2.8.5'
+        androidxNavigationVersion = '2.8.6'
         nexusPublishPluginVersion = '2.0.0'
     }
     dependencies {
@@ -39,10 +39,10 @@ ext {
     androidxCoreVersion = '1.15.0'
     androidxAppCompatVersion = '1.7.0'
     androidxConstraintLayoutVersion = '2.2.0'
-    androidxActivityVersion = '1.9.3'
+    androidxActivityVersion = '1.10.0'
     androidxFragmentVersion = '1.8.5'
     androidxLifecycleVersion = '2.8.7'
-    androidxRecyclerViewVersion = '1.3.2'
+    androidxRecyclerViewVersion = '1.4.0'
     androidxSwipeRefreshLayoutVersion = '1.1.0'
     androidxBrowserVersion = '1.8.0'
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/base/BaseBottomSheetDialogFragment.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/base/BaseBottomSheetDialogFragment.kt
@@ -32,7 +32,7 @@ import com.processout.sdk.ui.shared.extension.screenSize
 
 internal abstract class BaseBottomSheetDialogFragment<T : Parcelable> : BottomSheetDialogFragment() {
 
-    protected abstract val expandable: Boolean
+    protected abstract var expandable: Boolean
     protected abstract val defaultViewHeight: Int
     protected val screenHeight by lazy { requireContext().screenSize().height }
     protected var animationDurationMillis: Long = 400

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationBottomSheet.kt
@@ -79,7 +79,7 @@ internal class CardTokenizationBottomSheet : BaseBottomSheetDialogFragment<POCar
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        configuration?.let { apply(it.cancellation) }
+        configuration?.let { apply(it.bottomSheet.cancellation) }
     }
 
     private fun handle(completion: CardTokenizationCompletion) =

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationBottomSheet.kt
@@ -71,6 +71,9 @@ internal class CardTokenizationBottomSheet : BaseBottomSheetDialogFragment<POCar
                 CardTokenizationScreen(
                     state = viewModel.state.collectAsStateWithLifecycle().value,
                     onEvent = remember { viewModel::onEvent },
+                    onContentHeightChanged = { contentHeight ->
+                        // TODO
+                    },
                     style = CardTokenizationScreen.style(custom = configuration?.style)
                 )
             }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationBottomSheet.kt
@@ -34,7 +34,7 @@ internal class CardTokenizationBottomSheet : BaseBottomSheetDialogFragment<POCar
         val tag: String = CardTokenizationBottomSheet::class.java.simpleName
     }
 
-    override val expandable = false
+    override var expandable = false
     override val defaultViewHeight by lazy { screenHeight }
 
     private var configuration: POCardTokenizationConfiguration? = null
@@ -79,7 +79,10 @@ internal class CardTokenizationBottomSheet : BaseBottomSheetDialogFragment<POCar
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        configuration?.let { apply(it.bottomSheet.cancellation) }
+        configuration?.let {
+            expandable = it.bottomSheet.expandable
+            apply(it.bottomSheet.cancellation)
+        }
     }
 
     private fun handle(completion: CardTokenizationCompletion) =

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
@@ -129,7 +129,7 @@ internal class CardTokenizationInteractor(
         ),
         Field(
             id = CardFieldId.CARDHOLDER,
-            shouldCollect = configuration.isCardholderNameFieldVisible
+            shouldCollect = configuration.cardholderNameRequired
         )
     )
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
@@ -117,7 +117,7 @@ internal class CardTokenizationViewModel private constructor(
                     }
                 )
             },
-            draggable = cancellation.dragDown
+            draggable = bottomSheet.cancellation.dragDown
         )
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
@@ -117,7 +117,7 @@ internal class CardTokenizationViewModel private constructor(
                     }
                 )
             },
-            draggable = bottomSheet.cancellation.dragDown
+            draggable = bottomSheet.cancellation.dragDown || bottomSheet.expandable
         )
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
@@ -14,8 +14,8 @@ import kotlinx.parcelize.Parcelize
  * Defines card tokenization configuration.
  *
  * @param[title] Custom title.
- * @param[cvcRequired] Specifies whether the card CVC should be collected. Default value is _true_.
- * @param[isCardholderNameFieldVisible] Specifies whether the cardholder name field should be displayed. Default value is _true_.
+ * @param[cvcRequired] Specifies whether the CVC field should be displayed. Default value is _true_.
+ * @param[cardholderNameRequired] Specifies whether the cardholder name field should be displayed. Default value is _true_.
  * @param[billingAddress] Allows to customize the collection of billing address.
  * @param[savingAllowed] Displays checkbox that allows to save the card details for future payments.
  * @param[submitButton] Submit button configuration.
@@ -28,7 +28,7 @@ import kotlinx.parcelize.Parcelize
 data class POCardTokenizationConfiguration(
     val title: String? = null,
     val cvcRequired: Boolean = true,
-    val isCardholderNameFieldVisible: Boolean = true,
+    val cardholderNameRequired: Boolean = true,
     val billingAddress: BillingAddressConfiguration = BillingAddressConfiguration(),
     val savingAllowed: Boolean = false,
     val submitButton: Button = Button(),
@@ -42,7 +42,7 @@ data class POCardTokenizationConfiguration(
      * Defines card tokenization configuration.
      *
      * @param[title] Custom title.
-     * @param[cvcRequired] Specifies whether the card CVC should be collected. Default value is _true_.
+     * @param[cvcRequired] Specifies whether the CVC field should be displayed. Default value is _true_.
      * @param[isCardholderNameFieldVisible] Specifies whether the cardholder name field should be displayed. Default value is _true_.
      * @param[billingAddress] Allows to customize the collection of billing address.
      * @param[savingAllowed] Displays checkbox that allows to save the card details for future payments.
@@ -67,7 +67,7 @@ data class POCardTokenizationConfiguration(
     ) : this(
         title = title,
         cvcRequired = cvcRequired,
-        isCardholderNameFieldVisible = isCardholderNameFieldVisible,
+        cardholderNameRequired = isCardholderNameFieldVisible,
         billingAddress = billingAddress,
         savingAllowed = savingAllowed,
         submitButton = Button(text = primaryActionText),

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
@@ -7,6 +7,9 @@ import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration.B
 import com.processout.sdk.ui.core.shared.image.PODrawableImage
 import com.processout.sdk.ui.core.style.*
 import com.processout.sdk.ui.shared.configuration.POActionConfirmationConfiguration
+import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration
+import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration.Height.Fixed
+import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration.Height.WrapContent
 import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
 import kotlinx.parcelize.Parcelize
 
@@ -20,7 +23,7 @@ import kotlinx.parcelize.Parcelize
  * @param[savingAllowed] Displays checkbox that allows to save the card details for future payments.
  * @param[submitButton] Submit button configuration.
  * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
- * @param[cancellation] Specifies cancellation behaviour.
+ * @param[bottomSheet] Specifies bottom sheet configuration. By default is [WrapContent] and non-expandable.
  * @param[metadata] Metadata related to the card.
  * @param[style] Allows to customize the look and feel.
  */
@@ -33,7 +36,10 @@ data class POCardTokenizationConfiguration(
     val savingAllowed: Boolean = false,
     val submitButton: Button = Button(),
     val cancelButton: CancelButton? = CancelButton(),
-    val cancellation: POCancellationConfiguration = POCancellationConfiguration(),
+    val bottomSheet: POBottomSheetConfiguration = POBottomSheetConfiguration(
+        height = WrapContent,
+        expandable = false
+    ),
     val metadata: Map<String, String>? = null,
     val style: Style? = null
 ) : Parcelable {
@@ -73,7 +79,11 @@ data class POCardTokenizationConfiguration(
         submitButton = Button(text = primaryActionText),
         cancelButton = if (cancellation.secondaryAction)
             CancelButton(text = secondaryActionText) else null,
-        cancellation = cancellation,
+        bottomSheet = POBottomSheetConfiguration(
+            height = Fixed(1f),
+            expandable = false,
+            cancellation = cancellation
+        ),
         metadata = metadata,
         style = style
     )

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateBottomSheet.kt
@@ -32,7 +32,7 @@ internal class CardUpdateBottomSheet : BaseBottomSheetDialogFragment<POCard>() {
         val tag: String = CardUpdateBottomSheet::class.java.simpleName
     }
 
-    override val expandable = false
+    override var expandable = false
     override val defaultViewHeight by lazy { 440.dpToPx(requireContext()) }
 
     private var configuration: POCardUpdateConfiguration? = null

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -483,7 +483,7 @@ internal class DynamicCheckoutInteractor(
     private fun POCardTokenizationConfiguration.apply(configuration: CardConfiguration) =
         copy(
             cvcRequired = configuration.cvcRequired,
-            isCardholderNameFieldVisible = configuration.cardholderNameRequired,
+            cardholderNameRequired = configuration.cardholderNameRequired,
             billingAddress = billingAddress.copy(
                 mode = configuration.billingAddress.collectionMode.map(),
                 countryCodes = configuration.billingAddress.restrictToCountryCodes

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentBottomSheet.kt
@@ -42,7 +42,7 @@ internal class NativeAlternativePaymentBottomSheet : BaseBottomSheetDialogFragme
         val tag: String = NativeAlternativePaymentBottomSheet::class.java.simpleName
     }
 
-    override val expandable = true
+    override var expandable = true
     override val defaultViewHeight by lazy { 460.dpToPx(requireContext()) }
     private val maxPeekHeight by lazy { (screenHeight * 0.8).roundToInt() }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentScreen.kt
@@ -99,13 +99,13 @@ internal fun NativeAlternativePaymentScreen(
         bottomBar = {
             DynamicFooter {
                 Actions(
-                    modifier = Modifier.onGloballyPositioned {
-                        bottomBarHeight = it.size.height
-                    },
                     state = state,
                     onEvent = onEvent,
                     containerStyle = style.actionsContainer,
-                    dialogStyle = style.dialog
+                    dialogStyle = style.dialog,
+                    modifier = Modifier.onGloballyPositioned {
+                        bottomBarHeight = it.size.height
+                    }
                 )
             }
         }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsBottomSheet.kt
@@ -35,7 +35,7 @@ internal class SavedPaymentMethodsBottomSheet : BaseBottomSheetDialogFragment<PO
         val tag: String = SavedPaymentMethodsBottomSheet::class.java.simpleName
     }
 
-    override val expandable = false
+    override var expandable = false
     override val defaultViewHeight by lazy { screenHeight }
 
     private var configuration: POSavedPaymentMethodsConfiguration? = null

--- a/ui/src/main/kotlin/com/processout/sdk/ui/shared/configuration/POBottomSheetConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/shared/configuration/POBottomSheetConfiguration.kt
@@ -1,0 +1,40 @@
+package com.processout.sdk.ui.shared.configuration
+
+import android.os.Parcelable
+import androidx.annotation.FloatRange
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Specifies bottom sheet configuration.
+ *
+ * @param[height] Specifies bottom sheet height.
+ * @param[expandable] Specifies whether the bottom sheet is expandable.
+ * @param[cancellation] Specifies cancellation behaviour.
+ */
+@Parcelize
+data class POBottomSheetConfiguration(
+    val height: Height,
+    val expandable: Boolean,
+    val cancellation: POCancellationConfiguration = POCancellationConfiguration()
+) : Parcelable {
+
+    /**
+     * Specifies bottom sheet height.
+     */
+    sealed class Height : Parcelable {
+        /**
+         * Bottom sheet height will be fixed to the [fraction] of the screen height, between `0.5` and `1`, inclusive.
+         */
+        @Parcelize
+        data class Fixed(
+            @FloatRange(from = 0.5, to = 1.0)
+            val fraction: Float
+        ) : Height()
+
+        /**
+         * Bottom sheet height will change dynamically to wrap its content.
+         */
+        @Parcelize
+        data object WrapContent : Height()
+    }
+}


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
* Added generic `POBottomSheetConfiguration` which allows to set height as wrap content or fixed (in range 50-100%), expandable and cancellation.
* Applied to `POCardTokenizationConfiguration` and screen.
* Renamed `isCardholderNameFieldVisible` to `cardholderNameRequired` in new constructor.
* Updated libraries.

[wrap_content.webm](https://github.com/user-attachments/assets/e6b9ab81-76db-47f8-8f68-821309cf269a)

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-451
