### PR TITLE
feat(POM-451): Adjustable bottom sheet height

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.1.0" />
+    <option name="version" value="2.1.10" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@
 buildscript {
     ext {
         androidGradlePluginVersion = '8.8.0'
-        kotlinVersion = '2.1.0'
-        kspVersion = '2.1.0-1.0.29'
+        kotlinVersion = '2.1.10'
+        kspVersion = '2.1.10-1.0.29'
         dokkaVersion = '1.9.20'
         androidxNavigationVersion = '2.8.6'
         nexusPublishPluginVersion = '2.0.0'

--- a/example/src/main/kotlin/com/processout/example/ui/screen/features/FeaturesFragment.kt
+++ b/example/src/main/kotlin/com/processout/example/ui/screen/features/FeaturesFragment.kt
@@ -23,7 +23,8 @@ import com.processout.sdk.ui.card.update.POCardUpdateConfiguration
 import com.processout.sdk.ui.card.update.POCardUpdateConfiguration.CardInformation
 import com.processout.sdk.ui.card.update.POCardUpdateLauncher
 import com.processout.sdk.ui.googlepay.POGooglePayCardTokenizationLauncher
-import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
+import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration
+import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration.Height.WrapContent
 import com.processout.sdk.ui.shared.view.dialog.POAlertDialog
 import kotlinx.coroutines.launch
 
@@ -97,10 +98,9 @@ class FeaturesFragment : BaseFragment<FragmentFeaturesBinding>(
                             scheme = card?.scheme,
                             preferredScheme = card?.coScheme
                         ),
-                        cancellation = POCancellationConfiguration(
-                            backPressed = true,
-                            dragDown = true,
-                            touchOutside = false
+                        bottomSheet = POBottomSheetConfiguration(
+                            height = WrapContent,
+                            expandable = false
                         )
                     )
                 )

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Oct 05 19:43:19 EEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateBottomSheet.kt
@@ -21,9 +21,10 @@ import com.processout.sdk.ui.base.BaseBottomSheetDialogFragment
 import com.processout.sdk.ui.card.update.CardUpdateCompletion.Failure
 import com.processout.sdk.ui.card.update.CardUpdateCompletion.Success
 import com.processout.sdk.ui.card.update.CardUpdateEvent.Dismiss
-import com.processout.sdk.ui.card.update.POCardUpdateConfiguration.Button
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
 import com.processout.sdk.ui.shared.component.screenModeAsState
+import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration
+import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration.Height.WrapContent
 import com.processout.sdk.ui.shared.extension.dpToPx
 
 internal class CardUpdateBottomSheet : BaseBottomSheetDialogFragment<POCard>() {
@@ -42,7 +43,10 @@ internal class CardUpdateBottomSheet : BaseBottomSheetDialogFragment<POCard>() {
             app = requireActivity().application,
             configuration = configuration ?: POCardUpdateConfiguration(
                 cardId = String(),
-                submitButton = Button()
+                bottomSheet = POBottomSheetConfiguration(
+                    height = WrapContent,
+                    expandable = false
+                )
             )
         )
     }
@@ -88,7 +92,10 @@ internal class CardUpdateBottomSheet : BaseBottomSheetDialogFragment<POCard>() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        configuration?.let { apply(it.cancellation) }
+        configuration?.let {
+            expandable = it.bottomSheet.expandable
+            apply(it.bottomSheet.cancellation)
+        }
     }
 
     private fun handle(completion: CardUpdateCompletion) =

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateScreen.kt
@@ -5,9 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
@@ -16,8 +14,10 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import com.processout.sdk.ui.card.update.CardUpdateEvent.*
 import com.processout.sdk.ui.core.component.*
@@ -26,25 +26,36 @@ import com.processout.sdk.ui.core.component.field.text.POTextField
 import com.processout.sdk.ui.core.state.POActionState
 import com.processout.sdk.ui.core.state.POImmutableList
 import com.processout.sdk.ui.core.style.POAxis
-import com.processout.sdk.ui.core.theme.ProcessOutTheme
+import com.processout.sdk.ui.core.theme.ProcessOutTheme.colors
+import com.processout.sdk.ui.core.theme.ProcessOutTheme.dimensions
+import com.processout.sdk.ui.core.theme.ProcessOutTheme.shapes
+import com.processout.sdk.ui.core.theme.ProcessOutTheme.spacing
 import com.processout.sdk.ui.shared.component.DynamicFooter
 import com.processout.sdk.ui.shared.component.rememberLifecycleEvent
+import com.processout.sdk.ui.shared.extension.dpToPx
 import com.processout.sdk.ui.shared.state.FieldState
 
 @Composable
 internal fun CardUpdateScreen(
     state: CardUpdateState,
     onEvent: (CardUpdateEvent) -> Unit,
+    onContentHeightChanged: (Int) -> Unit,
     style: CardUpdateScreen.Style = CardUpdateScreen.style()
 ) {
+    var topBarHeight by remember { mutableIntStateOf(0) }
+    var bottomBarHeight by remember { mutableIntStateOf(0) }
     Scaffold(
         modifier = Modifier
             .nestedScroll(rememberNestedScrollInteropConnection())
-            .clip(shape = ProcessOutTheme.shapes.topRoundedCornersLarge),
+            .clip(shape = shapes.topRoundedCornersLarge),
         containerColor = style.backgroundColor,
         topBar = {
             POHeader(
-                modifier = Modifier.verticalScroll(rememberScrollState()),
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .onGloballyPositioned {
+                        topBarHeight = it.size.height
+                    },
                 title = state.title,
                 style = style.title,
                 dividerColor = style.dividerColor,
@@ -58,7 +69,10 @@ internal fun CardUpdateScreen(
                     primary = state.primaryAction,
                     secondary = state.secondaryAction,
                     onEvent = onEvent,
-                    style = style.actionsContainer
+                    style = style.actionsContainer,
+                    modifier = Modifier.onGloballyPositioned {
+                        bottomBarHeight = it.size.height
+                    }
                 )
             }
         }
@@ -68,21 +82,30 @@ internal fun CardUpdateScreen(
                 .fillMaxSize()
                 .padding(scaffoldPadding)
                 .verticalScroll(rememberScrollState())
-                .padding(ProcessOutTheme.spacing.extraLarge),
-            verticalArrangement = Arrangement.spacedBy(ProcessOutTheme.spacing.small)
+                .padding(spacing.extraLarge)
         ) {
-            Fields(
-                fields = state.fields,
-                onEvent = onEvent,
-                focusedFieldId = state.focusedFieldId,
-                isPrimaryActionEnabled = state.primaryAction.enabled && !state.primaryAction.loading,
-                style = style.field
-            )
-            POExpandableText(
-                text = state.errorMessage,
-                style = style.errorMessage,
-                modifier = Modifier.fillMaxWidth()
-            )
+            val verticalSpacingPx = (spacing.extraLarge * 4 + 10.dp).dpToPx()
+            Column(
+                modifier = Modifier.onGloballyPositioned {
+                    val contentHeight = it.size.height + topBarHeight + bottomBarHeight + verticalSpacingPx
+                    onContentHeightChanged(contentHeight)
+                }
+            ) {
+                Fields(
+                    fields = state.fields,
+                    onEvent = onEvent,
+                    focusedFieldId = state.focusedFieldId,
+                    isPrimaryActionEnabled = state.primaryAction.enabled && !state.primaryAction.loading,
+                    style = style.field
+                )
+                POExpandableText(
+                    text = state.errorMessage,
+                    style = style.errorMessage,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = spacing.small)
+                )
+            }
         }
     }
 }
@@ -95,49 +118,53 @@ private fun Fields(
     isPrimaryActionEnabled: Boolean,
     style: POField.Style
 ) {
-    val lifecycleEvent = rememberLifecycleEvent()
-    fields.elements.forEach { state ->
-        val focusRequester = remember { FocusRequester() }
-        POTextField(
-            value = state.value,
-            onValueChange = {
-                if (state.enabled) {
-                    onEvent(
-                        FieldValueChanged(
-                            id = state.id,
-                            value = state.inputFilter?.filter(it) ?: it
+    Column(
+        verticalArrangement = Arrangement.spacedBy(spacing.small)
+    ) {
+        val lifecycleEvent = rememberLifecycleEvent()
+        fields.elements.forEach { state ->
+            val focusRequester = remember { FocusRequester() }
+            POTextField(
+                value = state.value,
+                onValueChange = {
+                    if (state.enabled) {
+                        onEvent(
+                            FieldValueChanged(
+                                id = state.id,
+                                value = state.inputFilter?.filter(it) ?: it
+                            )
                         )
-                    )
-                }
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .focusRequester(focusRequester)
-                .onFocusChanged {
-                    onEvent(
-                        FieldFocusChanged(
-                            id = state.id,
-                            isFocused = it.isFocused
-                        )
-                    )
+                    }
                 },
-            style = style,
-            enabled = state.enabled,
-            readOnly = !state.enabled,
-            isError = state.isError,
-            forceTextDirectionLtr = state.forceTextDirectionLtr,
-            placeholderText = state.placeholder,
-            trailingIcon = { state.iconResId?.let { AnimatedFieldIcon(id = it) } },
-            keyboardOptions = state.keyboardOptions,
-            keyboardActions = POField.keyboardActions(
-                imeAction = state.keyboardOptions.imeAction,
-                actionId = state.keyboardActionId,
-                enabled = isPrimaryActionEnabled,
-                onClick = { onEvent(Action(id = it)) }
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester)
+                    .onFocusChanged {
+                        onEvent(
+                            FieldFocusChanged(
+                                id = state.id,
+                                isFocused = it.isFocused
+                            )
+                        )
+                    },
+                style = style,
+                enabled = state.enabled,
+                readOnly = !state.enabled,
+                isError = state.isError,
+                forceTextDirectionLtr = state.forceTextDirectionLtr,
+                placeholderText = state.placeholder,
+                trailingIcon = { state.iconResId?.let { AnimatedFieldIcon(id = it) } },
+                keyboardOptions = state.keyboardOptions,
+                keyboardActions = POField.keyboardActions(
+                    imeAction = state.keyboardOptions.imeAction,
+                    actionId = state.keyboardActionId,
+                    enabled = isPrimaryActionEnabled,
+                    onClick = { onEvent(Action(id = it)) }
+                )
             )
-        )
-        if (state.id == focusedFieldId && lifecycleEvent == Lifecycle.Event.ON_RESUME) {
-            PORequestFocus(focusRequester, lifecycleEvent)
+            if (state.id == focusedFieldId && lifecycleEvent == Lifecycle.Event.ON_RESUME) {
+                PORequestFocus(focusRequester, lifecycleEvent)
+            }
         }
     }
 }
@@ -147,7 +174,7 @@ private fun AnimatedFieldIcon(@DrawableRes id: Int) {
     POAnimatedImage(
         id = id,
         modifier = Modifier
-            .requiredHeight(ProcessOutTheme.dimensions.formComponentMinHeight)
+            .requiredHeight(dimensions.formComponentMinHeight)
             .padding(POField.contentPadding),
         contentScale = ContentScale.FillHeight
     )
@@ -158,11 +185,13 @@ private fun Actions(
     primary: POActionState,
     secondary: POActionState?,
     onEvent: (CardUpdateEvent) -> Unit,
-    style: POActionsContainer.Style
+    style: POActionsContainer.Style,
+    modifier: Modifier = Modifier
 ) {
     val actions = mutableListOf(primary)
     secondary?.let { actions.add(it) }
     POActionsContainer(
+        modifier = modifier,
         actions = POImmutableList(
             if (style.axis == POAxis.Horizontal) actions.reversed() else actions
         ),
@@ -200,12 +229,12 @@ internal object CardUpdateScreen {
         } ?: POActionsContainer.default,
         backgroundColor = custom?.backgroundColorResId?.let {
             colorResource(id = it)
-        } ?: ProcessOutTheme.colors.surface.default,
+        } ?: colors.surface.default,
         dividerColor = custom?.dividerColorResId?.let {
             colorResource(id = it)
-        } ?: ProcessOutTheme.colors.border.subtle,
+        } ?: colors.border.subtle,
         dragHandleColor = custom?.dragHandleColorResId?.let {
             colorResource(id = it)
-        } ?: ProcessOutTheme.colors.border.subtle
+        } ?: colors.border.subtle
     )
 }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateViewModel.kt
@@ -120,7 +120,7 @@ internal class CardUpdateViewModel private constructor(
                     }
                 )
             },
-            draggable = cancellation.dragDown
+            draggable = bottomSheet.cancellation.dragDown || bottomSheet.expandable
         )
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/POCardUpdateConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/POCardUpdateConfiguration.kt
@@ -7,6 +7,8 @@ import com.processout.sdk.ui.core.style.POActionsContainerStyle
 import com.processout.sdk.ui.core.style.POFieldStyle
 import com.processout.sdk.ui.core.style.POTextStyle
 import com.processout.sdk.ui.shared.configuration.POActionConfirmationConfiguration
+import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration
+import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration.Height.WrapContent
 import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
 import kotlinx.parcelize.Parcelize
 
@@ -18,7 +20,7 @@ import kotlinx.parcelize.Parcelize
  * @param[title] Custom title.
  * @param[submitButton] Submit button configuration.
  * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
- * @param[cancellation] Specifies cancellation behaviour.
+ * @param[bottomSheet] Specifies bottom sheet configuration. By default is [WrapContent] and non-expandable.
  * @param[style] Allows to customize the look and feel.
  */
 @Parcelize
@@ -28,9 +30,46 @@ data class POCardUpdateConfiguration(
     val title: String? = null,
     val submitButton: Button = Button(),
     val cancelButton: CancelButton? = CancelButton(),
-    val cancellation: POCancellationConfiguration = POCancellationConfiguration(),
+    val bottomSheet: POBottomSheetConfiguration = POBottomSheetConfiguration(
+        height = WrapContent,
+        expandable = false
+    ),
     val style: Style? = null
 ) : Parcelable {
+
+    /**
+     * Defines card update configuration.
+     *
+     * @param[cardId] Card ID.
+     * @param[cardInformation] Allows to provide card information that will be visible in UI.
+     * @param[title] Custom title.
+     * @param[submitButton] Submit button configuration.
+     * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
+     * @param[cancellation] Specifies cancellation behaviour.
+     * @param[style] Allows to customize the look and feel.
+     */
+    @Deprecated(message = "Use alternative constructor.")
+    constructor(
+        cardId: String,
+        cardInformation: CardInformation? = null,
+        title: String? = null,
+        submitButton: Button = Button(),
+        cancelButton: CancelButton? = CancelButton(),
+        cancellation: POCancellationConfiguration = POCancellationConfiguration(),
+        style: Style? = null
+    ) : this(
+        cardId = cardId,
+        cardInformation = cardInformation,
+        title = title,
+        submitButton = submitButton,
+        cancelButton = cancelButton,
+        bottomSheet = POBottomSheetConfiguration(
+            height = WrapContent,
+            expandable = false,
+            cancellation = cancellation
+        ),
+        style = style
+    )
 
     /**
      * Defines card update configuration.

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/DynamicCheckoutScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/screen/DynamicCheckoutScreen.kt
@@ -219,8 +219,9 @@ private fun ExpressCheckoutHeader(
 ) {
     Row(
         modifier = Modifier
+            .padding(bottom = spacing.large)
             .fillMaxWidth()
-            .padding(bottom = spacing.large),
+            .requiredHeightIn(min = dimensions.buttonIconSizeSmall),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsConfiguration.kt
@@ -7,7 +7,8 @@ import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 import com.processout.sdk.ui.core.shared.image.PODrawableImage
 import com.processout.sdk.ui.core.style.*
 import com.processout.sdk.ui.shared.configuration.POActionConfirmationConfiguration
-import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
+import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration
+import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration.Height.WrapContent
 import kotlinx.parcelize.Parcelize
 
 /** @suppress */
@@ -18,7 +19,10 @@ data class POSavedPaymentMethodsConfiguration(
     val title: String? = null,
     val deleteButton: Button = Button(),
     val cancelButton: Button? = Button(),
-    val cancellation: POCancellationConfiguration = POCancellationConfiguration(),
+    val bottomSheet: POBottomSheetConfiguration = POBottomSheetConfiguration(
+        height = WrapContent,
+        expandable = false
+    ),
     val style: Style? = null
 ) : Parcelable {
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsViewModel.kt
@@ -56,7 +56,7 @@ internal class SavedPaymentMethodsViewModel(
             title = title ?: app.getString(R.string.po_saved_payment_methods_title),
             content = content(state),
             cancelAction = cancelAction(id = state.cancelActionId),
-            draggable = cancellation.dragDown
+            draggable = bottomSheet.cancellation.dragDown || bottomSheet.expandable
         )
     }
 


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
* `POBottomSheetConfiguration` applied to Card Update and Saved Payment Methods screens.
* Saved Payment Methods screen wraps content by default and keeps minimum height at 38% of the screen.

[dc_saved_methods_wrap_content.webm](https://github.com/user-attachments/assets/7933284f-36a1-4936-8d86-98e25c08aff0)

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-451
