### PR TITLE
fix(ad-hoc): Finish SavedPaymentMethods on DC before transition to Success

### DIFF
--- a/ui/src/main/kotlin/com/processout/sdk/ui/base/BaseBottomSheetDialogFragment.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/base/BaseBottomSheetDialogFragment.kt
@@ -35,7 +35,7 @@ internal abstract class BaseBottomSheetDialogFragment<T : Parcelable> : BottomSh
     protected abstract var expandable: Boolean
     protected abstract val defaultViewHeight: Int
     protected val screenHeight by lazy { requireContext().screenSize().height }
-    protected var animationDurationMillis: Long = 400
+    protected open val animationDurationMillis: Long = 400
 
     private val bottomSheetDialog by lazy { requireDialog() as BottomSheetDialog }
     private val bottomSheetBehavior by lazy { bottomSheetDialog.behavior }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutEvent.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutEvent.kt
@@ -86,6 +86,8 @@ internal sealed interface DynamicCheckoutSideEffect {
     ) : DynamicCheckoutSideEffect
 
     data object CancelWebAuthorization : DynamicCheckoutSideEffect
+
+    data object BeforeSuccess : DynamicCheckoutSideEffect
 }
 
 internal sealed interface DynamicCheckoutCompletion {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -962,6 +962,9 @@ internal class DynamicCheckoutInteractor(
     }
 
     private fun handleSuccess() {
+        interactorScope.launch {
+            _sideEffects.send(DynamicCheckoutSideEffect.BeforeSuccess)
+        }
         configuration.paymentSuccess?.let { paymentSuccess ->
             _state.update { it.copy(delayedSuccess = true) }
             handler.postDelayed(delayInMillis = paymentSuccess.durationSeconds * 1000L) {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsLauncher.kt
@@ -1,6 +1,7 @@
 package com.processout.sdk.ui.savedpaymentmethods
 
 import android.content.Context
+import android.content.Intent
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.core.app.ActivityOptionsCompat
@@ -12,6 +13,7 @@ import com.processout.sdk.api.model.event.POSavedPaymentMethodsEvent
 import com.processout.sdk.core.POUnit
 import com.processout.sdk.core.ProcessOutActivityResult
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
+import com.processout.sdk.ui.savedpaymentmethods.SavedPaymentMethodsActivityContract.Companion.EXTRA_FORCE_FINISH
 import kotlinx.coroutines.CoroutineScope
 
 /**
@@ -20,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 /** @suppress */
 @ProcessOutInternalApi
 class POSavedPaymentMethodsLauncher private constructor(
+    private val parentActivity: ComponentActivity,
     private val scope: CoroutineScope,
     private val launcher: ActivityResultLauncher<POSavedPaymentMethodsConfiguration>,
     private val activityOptions: ActivityOptionsCompat,
@@ -37,6 +40,7 @@ class POSavedPaymentMethodsLauncher private constructor(
             delegate: POSavedPaymentMethodsDelegate,
             callback: (ProcessOutActivityResult<POUnit>) -> Unit
         ) = POSavedPaymentMethodsLauncher(
+            parentActivity = from.requireActivity(),
             scope = from.lifecycleScope,
             launcher = from.registerForActivityResult(
                 SavedPaymentMethodsActivityContract(),
@@ -55,6 +59,7 @@ class POSavedPaymentMethodsLauncher private constructor(
             delegate: POSavedPaymentMethodsDelegate,
             callback: (ProcessOutActivityResult<POUnit>) -> Unit
         ) = POSavedPaymentMethodsLauncher(
+            parentActivity = from,
             scope = from.lifecycleScope,
             launcher = from.registerForActivityResult(
                 SavedPaymentMethodsActivityContract(),
@@ -86,5 +91,16 @@ class POSavedPaymentMethodsLauncher private constructor(
      */
     fun launch(configuration: POSavedPaymentMethodsConfiguration) {
         launcher.launch(configuration, activityOptions)
+    }
+
+    /**
+     * Finishes the activity.
+     */
+    fun finish() {
+        Intent(parentActivity, SavedPaymentMethodsActivity::class.java).let {
+            it.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            it.putExtra(EXTRA_FORCE_FINISH, true)
+            parentActivity.startActivity(it)
+        }
     }
 }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsActivity.kt
@@ -1,13 +1,21 @@
 package com.processout.sdk.ui.savedpaymentmethods
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
+import com.processout.sdk.core.POFailure.Code.Cancelled
+import com.processout.sdk.core.ProcessOutResult
 import com.processout.sdk.ui.base.BaseTransparentPortraitActivity
+import com.processout.sdk.ui.savedpaymentmethods.SavedPaymentMethodsActivityContract.Companion.EXTRA_FORCE_FINISH
 
 internal class SavedPaymentMethodsActivity : BaseTransparentPortraitActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (intent.getBooleanExtra(EXTRA_FORCE_FINISH, false)) {
+            finish()
+            return
+        }
         enableEdgeToEdge()
         if (savedInstanceState == null) {
             val bottomSheet = supportFragmentManager.findFragmentByTag(SavedPaymentMethodsBottomSheet.tag)
@@ -18,5 +26,26 @@ internal class SavedPaymentMethodsActivity : BaseTransparentPortraitActivity() {
                 }
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        if (intent.getBooleanExtra(EXTRA_FORCE_FINISH, false)) {
+            forceFinish()
+        }
+    }
+
+    private fun forceFinish() {
+        val bottomSheet = supportFragmentManager.findFragmentByTag(SavedPaymentMethodsBottomSheet.tag)
+        if (bottomSheet == null) {
+            finish()
+            return
+        }
+        (bottomSheet as SavedPaymentMethodsBottomSheet).dismiss(
+            ProcessOutResult.Failure(
+                code = Cancelled,
+                message = "Cancelled: finished programmatically."
+            )
+        )
     }
 }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsActivityContract.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsActivityContract.kt
@@ -15,6 +15,7 @@ internal class SavedPaymentMethodsActivityContract : ActivityResultContract
     companion object {
         const val EXTRA_CONFIGURATION = "${BuildConfig.LIBRARY_PACKAGE_NAME}.EXTRA_CONFIGURATION"
         const val EXTRA_RESULT = "${BuildConfig.LIBRARY_PACKAGE_NAME}.EXTRA_RESULT"
+        const val EXTRA_FORCE_FINISH = "${BuildConfig.LIBRARY_PACKAGE_NAME}.EXTRA_FORCE_FINISH"
     }
 
     override fun createIntent(

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsBottomSheet.kt
@@ -130,7 +130,7 @@ internal class SavedPaymentMethodsBottomSheet : BaseBottomSheetDialogFragment<PO
 
     override fun onCancellation(failure: ProcessOutResult.Failure) = dismiss(failure)
 
-    private fun dismiss(failure: ProcessOutResult.Failure) {
+    fun dismiss(failure: ProcessOutResult.Failure) {
         viewModel.onEvent(Dismiss(failure))
         finishWithActivityResult(
             resultCode = Activity.RESULT_CANCELED,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsBottomSheet.kt
@@ -40,6 +40,7 @@ internal class SavedPaymentMethodsBottomSheet : BaseBottomSheetDialogFragment<PO
 
     override var expandable = false
     override val defaultViewHeight by lazy { 330.dpToPx(requireContext()) }
+    override val animationDurationMillis: Long = 300
 
     private var configuration: POSavedPaymentMethodsConfiguration? = null
     private val viewHeightConfiguration by lazy { configuration?.bottomSheet?.height ?: WrapContent }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsBottomSheet.kt
@@ -29,6 +29,7 @@ import com.processout.sdk.ui.shared.component.displayCutoutHeight
 import com.processout.sdk.ui.shared.component.screenModeAsState
 import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration.Height.Fixed
 import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration.Height.WrapContent
+import com.processout.sdk.ui.shared.extension.dpToPx
 import kotlin.math.roundToInt
 
 internal class SavedPaymentMethodsBottomSheet : BaseBottomSheetDialogFragment<POUnit>() {
@@ -38,7 +39,7 @@ internal class SavedPaymentMethodsBottomSheet : BaseBottomSheetDialogFragment<PO
     }
 
     override var expandable = false
-    override val defaultViewHeight by lazy { (screenHeight * 0.38).roundToInt() }
+    override val defaultViewHeight by lazy { 330.dpToPx(requireContext()) }
 
     private var configuration: POSavedPaymentMethodsConfiguration? = null
     private val viewHeightConfiguration by lazy { configuration?.bottomSheet?.height ?: WrapContent }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsInteractor.kt
@@ -155,7 +155,9 @@ internal class SavedPaymentMethodsInteractor(
                 ActionId.DELETE -> event.paymentMethodId?.let { delete(it) }
                 ActionId.CANCEL -> cancel()
             }
-            is Dismiss -> {}
+            is Dismiss -> {
+                // TODO
+            }
         }
     }
 


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
* Finish SavedPaymentMethods on DC before transition to Success.
* AnimatedContent on DC instead of Crossfade and custom animations.
* SavedPaymentMethods bottom sheet height and animation adjustment.

Bug:

[bug.webm](https://github.com/user-attachments/assets/0b40fab9-588c-4e92-9b2e-a8e08b1e8cc8)

Fixed:

[fixed.webm](https://github.com/user-attachments/assets/d3e89eb3-4a0f-44fc-a663-87bbba25ef1a)
