### PR TITLE
fix(ad-hoc): Edge-to-edge dialog

### DIFF
--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/PODialog.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/PODialog.kt
@@ -1,5 +1,9 @@
 package com.processout.sdk.ui.core.component
 
+import android.os.Build
+import android.view.ViewGroup
+import android.view.WindowInsets
+import android.view.WindowManager
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Card
@@ -9,9 +13,11 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.DialogWindowProvider
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 import com.processout.sdk.ui.core.component.PODialog.cardColors
 import com.processout.sdk.ui.core.style.PODialogStyle
@@ -36,9 +42,11 @@ fun PODialog(
         properties = DialogProperties(
             dismissOnBackPress = false,
             dismissOnClickOutside = false,
-            usePlatformDefaultWidth = false
+            usePlatformDefaultWidth = true, // needs to be 'true', otherwise breaks insets, window adjusted below
+            decorFitsSystemWindows = Build.VERSION.SDK_INT < Build.VERSION_CODES.R
         )
     ) {
+        AdjustWindow()
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -99,6 +107,18 @@ fun PODialog(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun AdjustWindow() {
+    with((LocalView.current.parent as DialogWindowProvider).window) {
+        setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+        addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        setWindowAnimations(-1)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            attributes.fitInsetsSides = WindowInsets.Side.TOP
         }
     }
 }

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/PODialog.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/PODialog.kt
@@ -9,19 +9,18 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardColors
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
-import com.processout.sdk.ui.core.component.PODialog.cardColors
 import com.processout.sdk.ui.core.style.PODialogStyle
 import com.processout.sdk.ui.core.theme.ProcessOutTheme.colors
 import com.processout.sdk.ui.core.theme.ProcessOutTheme.dimensions
@@ -68,12 +67,14 @@ fun PODialog(
                 ),
             contentAlignment = Alignment.Center
         ) {
-            Card(
+            Surface(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(spacing.extraLarge),
                 shape = shapes.roundedCornersLarge,
-                colors = cardColors(style.backgroundColor)
+                color = style.backgroundColor,
+                contentColor = Color.Unspecified,
+                shadowElevation = 3.dp
             ) {
                 Column(
                     modifier = Modifier
@@ -129,6 +130,7 @@ private fun AdjustWindow() {
     with((LocalView.current.parent as DialogWindowProvider).window) {
         setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
         addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        setDimAmount(0f)
         setWindowAnimations(-1)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             attributes.fitInsetsSides = WindowInsets.Side.TOP
@@ -176,11 +178,4 @@ object PODialog {
             backgroundColor = colorResource(id = backgroundColorResId)
         )
     }
-
-    internal fun cardColors(backgroundColor: Color) = CardColors(
-        containerColor = backgroundColor,
-        contentColor = Color.Unspecified,
-        disabledContainerColor = Color.Unspecified,
-        disabledContentColor = Color.Unspecified
-    )
 }

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/PODialog.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/PODialog.kt
@@ -4,12 +4,14 @@ import android.os.Build
 import android.view.ViewGroup
 import android.view.WindowInsets
 import android.view.WindowManager
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -47,10 +49,22 @@ fun PODialog(
         )
     ) {
         AdjustWindow()
+        var scrimAlpha by remember { mutableFloatStateOf(0f) }
+        LaunchedEffect(Unit) { scrimAlpha = 0.32f }
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(color = PODialog.ScrimColor),
+                .background(
+                    color = Color.Black.copy(
+                        alpha = animateFloatAsState(
+                            targetValue = scrimAlpha,
+                            animationSpec = tween(
+                                durationMillis = 200,
+                                easing = FastOutLinearInEasing
+                            )
+                        ).value
+                    )
+                ),
             contentAlignment = Alignment.Center
         ) {
             with(ProcessOutTheme) {
@@ -163,8 +177,6 @@ object PODialog {
             backgroundColor = colorResource(id = backgroundColorResId)
         )
     }
-
-    internal val ScrimColor = Color.Black.copy(alpha = 0.32f)
 
     internal fun cardColors(backgroundColor: Color) = CardColors(
         containerColor = backgroundColor,

--- a/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/PODialog.kt
+++ b/ui-core/src/main/kotlin/com/processout/sdk/ui/core/component/PODialog.kt
@@ -23,8 +23,9 @@ import androidx.compose.ui.window.DialogWindowProvider
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 import com.processout.sdk.ui.core.component.PODialog.cardColors
 import com.processout.sdk.ui.core.style.PODialogStyle
-import com.processout.sdk.ui.core.theme.ProcessOutTheme
 import com.processout.sdk.ui.core.theme.ProcessOutTheme.colors
+import com.processout.sdk.ui.core.theme.ProcessOutTheme.dimensions
+import com.processout.sdk.ui.core.theme.ProcessOutTheme.shapes
 import com.processout.sdk.ui.core.theme.ProcessOutTheme.spacing
 
 /** @suppress */
@@ -67,57 +68,55 @@ fun PODialog(
                 ),
             contentAlignment = Alignment.Center
         ) {
-            with(ProcessOutTheme) {
-                Card(
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(spacing.extraLarge),
+                shape = shapes.roundedCornersLarge,
+                colors = cardColors(style.backgroundColor)
+            ) {
+                Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(spacing.extraLarge),
-                    shape = shapes.roundedCornersLarge,
-                    colors = cardColors(style.backgroundColor)
+                        .padding(spacing.extraLarge)
                 ) {
-                    Column(
+                    POText(
+                        text = title,
+                        color = style.title.color,
+                        style = style.title.textStyle
+                    )
+                    if (!message.isNullOrBlank()) {
+                        POText(
+                            text = message,
+                            modifier = Modifier.padding(top = spacing.large),
+                            color = style.message.color,
+                            style = style.message.textStyle
+                        )
+                    }
+                    Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(spacing.extraLarge)
+                            .padding(top = spacing.extraLarge),
+                        horizontalArrangement = Arrangement.spacedBy(
+                            space = spacing.small,
+                            alignment = Alignment.End
+                        ),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        POText(
-                            text = title,
-                            color = style.title.color,
-                            style = style.title.textStyle
-                        )
-                        if (!message.isNullOrBlank()) {
-                            POText(
-                                text = message,
-                                modifier = Modifier.padding(top = spacing.large),
-                                color = style.message.color,
-                                style = style.message.textStyle
-                            )
-                        }
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(top = spacing.extraLarge),
-                            horizontalArrangement = Arrangement.spacedBy(
-                                space = spacing.small,
-                                alignment = Alignment.End
-                            ),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            if (!dismissActionText.isNullOrBlank()) {
-                                POButton(
-                                    text = dismissActionText,
-                                    onClick = onDismiss,
-                                    modifier = Modifier.requiredHeightIn(min = dimensions.interactiveComponentMinSize),
-                                    style = style.dismissButton
-                                )
-                            }
+                        if (!dismissActionText.isNullOrBlank()) {
                             POButton(
-                                text = confirmActionText,
-                                onClick = onConfirm,
+                                text = dismissActionText,
+                                onClick = onDismiss,
                                 modifier = Modifier.requiredHeightIn(min = dimensions.interactiveComponentMinSize),
-                                style = style.confirmButton
+                                style = style.dismissButton
                             )
                         }
+                        POButton(
+                            text = confirmActionText,
+                            onClick = onConfirm,
+                            modifier = Modifier.requiredHeightIn(min = dimensions.interactiveComponentMinSize),
+                            style = style.confirmButton
+                        )
                     }
                 }
             }


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
* Workaround to enable edge-to-edge for Compose dialog. Note: scrim still doesn't cover status bar on some Android versions, but it always covers navigation bar and fixes enter transition glitch, which overall looks good.
* Custom enter animation.

Bug:

[dialog_bug.webm](https://github.com/user-attachments/assets/37438f89-191b-4a50-9f08-9808cd27e392)

Fixed:

[dialog_fixed.webm](https://github.com/user-attachments/assets/3c9bbc79-ecfa-44fb-8c0c-e29719014191)

