### PR TITLE
feat(ad-hoc): SavedPaymentMethods finalization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,10 +57,10 @@ ext {
     retrofitVersion = '2.11.0'
     moshiVersion = '1.15.2'
     okhttpVersion = '4.12.0'
-    okioVersion = '3.9.1'
+    okioVersion = '3.10.2'
     coilVersion = '2.7.0'
     commonMarkVersion = '0.24.0'
-    libphonenumberVersion = '8.13.52'
+    libphonenumberVersion = '8.13.54'
     zxingVersion = '3.5.3'
 
     checkout3dsSdkVersion = '3.2.4'

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/event/POSavedPaymentMethodsEvent.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/event/POSavedPaymentMethodsEvent.kt
@@ -1,13 +1,10 @@
 package com.processout.sdk.api.model.event
 
 import com.processout.sdk.core.ProcessOutResult
-import com.processout.sdk.core.annotation.ProcessOutInternalApi
 
 /**
  * Defines saved payment methods lifecycle events.
  */
-/** @suppress */
-@ProcessOutInternalApi
 sealed class POSavedPaymentMethodsEvent {
 
     /**

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
@@ -177,7 +177,7 @@ internal class CardTokenizationInteractor(
                 ActionId.SUBMIT -> submit()
                 ActionId.CANCEL -> cancel()
             }
-            is Dismiss -> POLogger.warn("Dismissed: %s", event.failure)
+            is Dismiss -> POLogger.info("Dismissed: %s", event.failure)
         }
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateViewModel.kt
@@ -229,10 +229,7 @@ internal class CardUpdateViewModel private constructor(
                 ActionId.SUBMIT -> submit()
                 ActionId.CANCEL -> cancel()
             }
-            is Dismiss -> POLogger.warn(
-                message = "Dismissed: %s", event.failure,
-                attributes = logAttributes
-            )
+            is Dismiss -> POLogger.info("Dismissed: %s", event.failure)
         }
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -1073,7 +1073,7 @@ internal class DynamicCheckoutInteractor(
         if (_state.value.delayedSuccess) {
             _completion.update { Success }
         } else {
-            POLogger.warn("Dismissed: %s", event.failure)
+            POLogger.info("Dismissed: %s", event.failure)
             _completion.update { Failure(event.failure) }
         }
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
@@ -432,7 +432,7 @@ internal class NativeAlternativePaymentInteractor(
             }
             is PermissionRequestResult -> handlePermission(event)
             is Dismiss -> {
-                POLogger.warn("Dismissed: %s", event.failure, attributes = logAttributes)
+                POLogger.info("Dismissed: %s", event.failure)
                 dispatch(DidFail(event.failure))
             }
         }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsConfiguration.kt
@@ -10,6 +10,17 @@ import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration
 import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration.Height.WrapContent
 import kotlinx.parcelize.Parcelize
 
+/**
+ * Specifies saved payment methods configuration.
+ *
+ * @param[invoiceRequest] Invoice request.
+ * __Note:__ Make sure that [POInvoiceRequest.clientSecret] is set to include saved payment methods in the response.
+ * @param[title] Custom title.
+ * @param[deleteButton] Payment method's delete button configuration.
+ * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
+ * @param[bottomSheet] Specifies bottom sheet configuration. By default will wrap content and is non-expandable.
+ * @param[style] Custom screen style.
+ */
 @Parcelize
 data class POSavedPaymentMethodsConfiguration(
     val invoiceRequest: POInvoiceRequest,
@@ -23,6 +34,14 @@ data class POSavedPaymentMethodsConfiguration(
     val style: Style? = null
 ) : Parcelable {
 
+    /**
+     * Button configuration.
+     *
+     * @param[text] Button text. Pass _null_ to hide.
+     * @param[icon] Button icon drawable resource. Pass _null_ to use the default icon.
+     * @param[confirmation] Specifies action confirmation configuration (e.g. dialog).
+     * Use _null_ to disable, this is a default behaviour.
+     */
     @Parcelize
     data class Button(
         val text: String? = null,
@@ -30,6 +49,17 @@ data class POSavedPaymentMethodsConfiguration(
         val confirmation: POActionConfirmationConfiguration? = null
     ) : Parcelable
 
+    /**
+     * Specifies screen style.
+     *
+     * @param[header] Screen header style.
+     * @param[paymentMethod] Payment method style.
+     * @param[messageBox] Message box style.
+     * @param[dialog] Dialog style.
+     * @param[cancelButton] Cancel button style.
+     * @param[progressIndicatorColorResId] Color resource ID for progress indicator.
+     * @param[backgroundColorResId] Color resource ID for background.
+     */
     @Parcelize
     data class Style(
         val header: HeaderStyle? = null,
@@ -43,6 +73,14 @@ data class POSavedPaymentMethodsConfiguration(
         val backgroundColorResId: Int? = null
     ) : Parcelable
 
+    /**
+     * Specifies screen header style.
+     *
+     * @param[title] Title style.
+     * @param[dragHandleColorResId] Color resource ID for drag handle.
+     * @param[dividerColorResId] Color resource ID for divider.
+     * @param[backgroundColorResId] Color resource ID for background.
+     */
     @Parcelize
     data class HeaderStyle(
         val title: POTextStyle,
@@ -54,6 +92,14 @@ data class POSavedPaymentMethodsConfiguration(
         val backgroundColorResId: Int? = null
     ) : Parcelable
 
+    /**
+     * Specifies payment method style.
+     *
+     * @param[description] Description style.
+     * @param[deleteButton] Delete button style.
+     * @param[border] Border style.
+     * @param[backgroundColorResId] Color resource ID for background.
+     */
     @Parcelize
     data class PaymentMethodStyle(
         val description: POTextStyle,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsConfiguration.kt
@@ -3,7 +3,6 @@ package com.processout.sdk.ui.savedpaymentmethods
 import android.os.Parcelable
 import androidx.annotation.ColorRes
 import com.processout.sdk.api.model.request.POInvoiceRequest
-import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 import com.processout.sdk.ui.core.shared.image.PODrawableImage
 import com.processout.sdk.ui.core.style.*
 import com.processout.sdk.ui.shared.configuration.POActionConfirmationConfiguration
@@ -11,8 +10,6 @@ import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration
 import com.processout.sdk.ui.shared.configuration.POBottomSheetConfiguration.Height.WrapContent
 import kotlinx.parcelize.Parcelize
 
-/** @suppress */
-@ProcessOutInternalApi
 @Parcelize
 data class POSavedPaymentMethodsConfiguration(
     val invoiceRequest: POInvoiceRequest,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsDelegate.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsDelegate.kt
@@ -1,13 +1,10 @@
 package com.processout.sdk.ui.savedpaymentmethods
 
 import com.processout.sdk.api.model.event.POSavedPaymentMethodsEvent
-import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 
 /**
  * Delegates events during management of saved payment methods.
  */
-/** @suppress */
-@ProcessOutInternalApi
 interface POSavedPaymentMethodsDelegate {
 
     /**

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsLauncher.kt
@@ -12,15 +12,12 @@ import com.processout.sdk.api.dispatcher.POEventDispatcher
 import com.processout.sdk.api.model.event.POSavedPaymentMethodsEvent
 import com.processout.sdk.core.POUnit
 import com.processout.sdk.core.ProcessOutActivityResult
-import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 import com.processout.sdk.ui.savedpaymentmethods.SavedPaymentMethodsActivityContract.Companion.EXTRA_FORCE_FINISH
 import kotlinx.coroutines.CoroutineScope
 
 /**
  * Launcher that starts [SavedPaymentMethodsActivity] and provides the result.
  */
-/** @suppress */
-@ProcessOutInternalApi
 class POSavedPaymentMethodsLauncher private constructor(
     private val parentActivity: ComponentActivity,
     private val scope: CoroutineScope,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsInteractor.kt
@@ -156,7 +156,8 @@ internal class SavedPaymentMethodsInteractor(
                 ActionId.CANCEL -> cancel()
             }
             is Dismiss -> {
-                // TODO
+                POLogger.info("Dismissed: %s", event.failure)
+                dispatch(DidFail(event.failure))
             }
         }
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsInteractor.kt
@@ -165,6 +165,10 @@ internal class SavedPaymentMethodsInteractor(
 
     private fun delete(customerTokenId: String) {
         val customerId = _state.value.customerId ?: return
+        val logAttributes = logAttributes.toMutableMap().apply {
+            put(POLogAttribute.CUSTOMER_ID, customerId)
+            put(POLogAttribute.CUSTOMER_TOKEN_ID, customerTokenId)
+        }
         interactorScope.launch {
             update(
                 customerTokenId = customerTokenId,
@@ -184,6 +188,7 @@ internal class SavedPaymentMethodsInteractor(
                             .filterNot { it.customerTokenId == customerTokenId }
                     )
                 }
+                POLogger.info("Deleted the customer token.", attributes = logAttributes)
                 dispatch(
                     DidDeleteCustomerToken(
                         customerId = customerId,
@@ -191,10 +196,6 @@ internal class SavedPaymentMethodsInteractor(
                     )
                 )
             }.onFailure { failure ->
-                val logAttributes = logAttributes.toMutableMap().apply {
-                    put(POLogAttribute.CUSTOMER_ID, customerId)
-                    put(POLogAttribute.CUSTOMER_TOKEN_ID, customerTokenId)
-                }
                 POLogger.warn("Failed to delete the customer token: %s", failure, attributes = logAttributes)
                 update(
                     customerTokenId = customerTokenId,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsInteractor.kt
@@ -64,7 +64,7 @@ internal class SavedPaymentMethodsInteractor(
             dispatch(WillStart)
             dispatchFailure()
             fetchPaymentMethods()
-            POLogger.info("Started.")
+            POLogger.info("Started saved payment methods.")
             dispatch(DidStart)
         }
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsInteractor.kt
@@ -89,6 +89,7 @@ internal class SavedPaymentMethodsInteractor(
                     )
                 }
             }.onFailure { failure ->
+                POLogger.warn("Failed to fetch the invoice: %s", failure, attributes = logAttributes)
                 _completion.update { Failure(failure) }
             }
     }
@@ -189,7 +190,12 @@ internal class SavedPaymentMethodsInteractor(
                         tokenId = customerTokenId
                     )
                 )
-            }.onFailure {
+            }.onFailure { failure ->
+                val logAttributes = logAttributes.toMutableMap().apply {
+                    put(POLogAttribute.CUSTOMER_ID, customerId)
+                    put(POLogAttribute.CUSTOMER_TOKEN_ID, customerTokenId)
+                }
+                POLogger.warn("Failed to delete the customer token: %s", failure, attributes = logAttributes)
                 update(
                     customerTokenId = customerTokenId,
                     processing = false,


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
Standalone SavedPaymentMethods screen is ready for release:
* Added logs and docs.
* Dispatching events.
* Removed ProcessOutInternalApi annotation from related classes.

Misc:
* `Dismiss` log level changed from `warn` to `info` on all screens.
* Updated libs.
