### PR TITLE
fix(POM-521): (Card Tokenization) Support multiple view component instances

### DIFF
--- a/sdk/src/main/kotlin/com/processout/sdk/api/dispatcher/POEventDispatcher.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/dispatcher/POEventDispatcher.kt
@@ -12,7 +12,13 @@ import java.util.UUID
 
 /** @suppress */
 @ProcessOutInternalApi
-object POEventDispatcher {
+class POEventDispatcher {
+
+    companion object {
+        val instance: POEventDispatcher by lazy {
+            POEventDispatcher()
+        }
+    }
 
     interface Request {
         val uuid: UUID

--- a/sdk/src/main/kotlin/com/processout/sdk/api/service/proxy3ds/PODefaultProxy3DSService.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/service/proxy3ds/PODefaultProxy3DSService.kt
@@ -21,7 +21,7 @@ class PODefaultProxy3DSService(
 ) : POProxy3DSService {
 
     private val uuid = UUID.randomUUID()
-    private val eventDispatcher = POEventDispatcher
+    private val eventDispatcher = POEventDispatcher.instance
 
     private var authenticationCallback: ((ProcessOutResult<PO3DS2AuthenticationRequest>) -> Unit)? = null
     private var challengeCallback: ((ProcessOutResult<Boolean>) -> Unit)? = null

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
@@ -60,7 +60,7 @@ internal class CardTokenizationInteractor(
     private val cardsRepository: POCardsRepository,
     private val cardSchemeProvider: CardSchemeProvider,
     private val addressSpecificationProvider: AddressSpecificationProvider,
-    private val eventDispatcher: POEventDispatcher = POEventDispatcher
+    private val eventDispatcher: POEventDispatcher = POEventDispatcher.instance
 ) : BaseInteractor() {
 
     private companion object {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
@@ -60,7 +60,7 @@ internal class CardTokenizationInteractor(
     private val cardsRepository: POCardsRepository,
     private val cardSchemeProvider: CardSchemeProvider,
     private val addressSpecificationProvider: AddressSpecificationProvider,
-    private val eventDispatcher: POEventDispatcher = POEventDispatcher.instance
+    private val eventDispatcher: POEventDispatcher
 ) : BaseInteractor() {
 
     private companion object {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.processout.sdk.R
 import com.processout.sdk.api.ProcessOut
+import com.processout.sdk.api.dispatcher.POEventDispatcher
 import com.processout.sdk.ui.card.tokenization.CardTokenizationInteractorState.*
 import com.processout.sdk.ui.card.tokenization.CardTokenizationViewModelState.*
 import com.processout.sdk.ui.core.shared.image.PODrawableImage
@@ -40,7 +41,8 @@ internal class CardTokenizationViewModel private constructor(
 
     class Factory(
         private val app: Application,
-        private val configuration: POCardTokenizationConfiguration
+        private val configuration: POCardTokenizationConfiguration,
+        private val eventDispatcher: POEventDispatcher = POEventDispatcher.instance
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T =
@@ -52,7 +54,8 @@ internal class CardTokenizationViewModel private constructor(
                     configuration = configuration,
                     cardsRepository = ProcessOut.instance.cards,
                     cardSchemeProvider = CardSchemeProvider(),
-                    addressSpecificationProvider = AddressSpecificationProvider(app)
+                    addressSpecificationProvider = AddressSpecificationProvider(app),
+                    eventDispatcher = eventDispatcher
                 )
             ) as T
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationLauncher.kt
@@ -30,7 +30,7 @@ class POCardTokenizationLauncher private constructor(
     private val launcher: ActivityResultLauncher<POCardTokenizationConfiguration>,
     private val activityOptions: ActivityOptionsCompat,
     private val delegate: POCardTokenizationDelegate,
-    private val eventDispatcher: POEventDispatcher = POEventDispatcher
+    private val eventDispatcher: POEventDispatcher = POEventDispatcher.instance
 ) {
 
     companion object {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/component/POCardTokenizationViewComponent.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/component/POCardTokenizationViewComponent.kt
@@ -61,7 +61,7 @@ class POCardTokenizationViewComponent private constructor(
     private val cardScannerLauncher: POCardScannerLauncher,
     private val delegate: POCardTokenizationDelegate,
     private val callback: (ProcessOutResult<POCard>) -> Unit,
-    private val eventDispatcher: POEventDispatcher = POEventDispatcher
+    private val eventDispatcher: POEventDispatcher = POEventDispatcher.instance
 ) {
 
     private val scope = lifecycleOwner.lifecycleScope

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/component/POCardTokenizationViewComponent.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/component/POCardTokenizationViewComponent.kt
@@ -61,7 +61,7 @@ class POCardTokenizationViewComponent private constructor(
     private val cardScannerLauncher: POCardScannerLauncher,
     private val delegate: POCardTokenizationDelegate,
     private val callback: (ProcessOutResult<POCard>) -> Unit,
-    private val eventDispatcher: POEventDispatcher = POEventDispatcher.instance
+    private val eventDispatcher: POEventDispatcher
 ) {
 
     private val scope = lifecycleOwner.lifecycleScope
@@ -78,10 +78,12 @@ class POCardTokenizationViewComponent private constructor(
             callback: (ProcessOutResult<POCard>) -> Unit
         ): POCardTokenizationViewComponent {
             val configuration = configuration.map()
+            val eventDispatcher = POEventDispatcher()
             val viewModel: CardTokenizationViewModel by from.viewModels {
                 CardTokenizationViewModel.Factory(
                     app = from.requireActivity().application,
-                    configuration = configuration
+                    configuration = configuration,
+                    eventDispatcher = eventDispatcher
                 )
             }
             return POCardTokenizationViewComponent(
@@ -100,7 +102,8 @@ class POCardTokenizationViewComponent private constructor(
                     }
                 ),
                 delegate = delegate,
-                callback = callback
+                callback = callback,
+                eventDispatcher = eventDispatcher
             )
         }
 
@@ -115,10 +118,12 @@ class POCardTokenizationViewComponent private constructor(
             callback: (ProcessOutResult<POCard>) -> Unit
         ): POCardTokenizationViewComponent {
             val configuration = configuration.map()
+            val eventDispatcher = POEventDispatcher()
             val viewModel: CardTokenizationViewModel by from.viewModels {
                 CardTokenizationViewModel.Factory(
                     app = from.application,
-                    configuration = configuration
+                    configuration = configuration,
+                    eventDispatcher = eventDispatcher
                 )
             }
             return POCardTokenizationViewComponent(
@@ -137,7 +142,8 @@ class POCardTokenizationViewComponent private constructor(
                     }
                 ),
                 delegate = delegate,
-                callback = callback
+                callback = callback,
+                eventDispatcher = eventDispatcher
             )
         }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/CardUpdateViewModel.kt
@@ -58,7 +58,7 @@ internal class CardUpdateViewModel private constructor(
                 app = app,
                 configuration = configuration,
                 cardsRepository = ProcessOut.instance.cards,
-                eventDispatcher = POEventDispatcher,
+                eventDispatcher = POEventDispatcher.instance,
                 logAttributes = mapOf(POLogAttribute.CARD_ID to configuration.cardId)
             ) as T
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/update/POCardUpdateLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/update/POCardUpdateLauncher.kt
@@ -25,7 +25,7 @@ class POCardUpdateLauncher private constructor(
     private val launcher: ActivityResultLauncher<POCardUpdateConfiguration>,
     private val activityOptions: ActivityOptionsCompat,
     private val delegate: POCardUpdateDelegate,
-    private val eventDispatcher: POEventDispatcher = POEventDispatcher
+    private val eventDispatcher: POEventDispatcher = POEventDispatcher.instance
 ) {
 
     companion object {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -78,7 +78,7 @@ internal class DynamicCheckoutInteractor(
     private val googlePayService: POGooglePayService,
     private val cardTokenization: CardTokenizationViewModel,
     private val nativeAlternativePayment: NativeAlternativePaymentViewModel,
-    private val eventDispatcher: POEventDispatcher = POEventDispatcher,
+    private val eventDispatcher: POEventDispatcher = POEventDispatcher.instance,
     private var logAttributes: Map<String, String> = logAttributes(
         invoiceId = configuration.invoiceRequest.invoiceId
     )

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutLauncher.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.lifecycleScope
 import com.processout.sdk.R
 import com.processout.sdk.api.dispatcher.POEventDispatcher
 import com.processout.sdk.api.model.event.POCardTokenizationEvent
-import com.processout.sdk.api.model.request.*
+import com.processout.sdk.api.model.request.POCardTokenizationPreferredSchemeRequest
 import com.processout.sdk.api.model.response.toResponse
 import com.processout.sdk.api.service.PO3DSService
 import com.processout.sdk.api.service.proxy3ds.POProxy3DSServiceRequest
@@ -24,7 +24,8 @@ import com.processout.sdk.ui.checkout.delegate.*
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 import com.processout.sdk.ui.napm.delegate.PONativeAlternativePaymentEvent
 import com.processout.sdk.ui.savedpaymentmethods.delegate.POSavedPaymentMethodsEvent
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * Launcher that starts [PODynamicCheckoutActivity] and provides the result.
@@ -37,7 +38,7 @@ class PODynamicCheckoutLauncher private constructor(
     private val activityOptions: ActivityOptionsCompat,
     private val threeDSService: PO3DSService,
     private val delegate: PODynamicCheckoutDelegate,
-    private val eventDispatcher: POEventDispatcher = POEventDispatcher
+    private val eventDispatcher: POEventDispatcher = POEventDispatcher.instance
 ) {
 
     companion object {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
@@ -82,7 +82,7 @@ internal class NativeAlternativePaymentInteractor(
     private val barcodeBitmapProvider: BarcodeBitmapProvider,
     private val mediaStorageProvider: MediaStorageProvider,
     private val captureRetryStrategy: PORetryStrategy,
-    private val eventDispatcher: POEventDispatcher = POEventDispatcher,
+    private val eventDispatcher: POEventDispatcher = POEventDispatcher.instance,
     private var logAttributes: Map<String, String> = logAttributes(configuration.flow)
 ) : BaseInteractor() {
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/PONativeAlternativePaymentLauncher.kt
@@ -25,7 +25,7 @@ class PONativeAlternativePaymentLauncher private constructor(
     private val launcher: ActivityResultLauncher<PONativeAlternativePaymentConfiguration>,
     private val activityOptions: ActivityOptionsCompat,
     private val delegate: PONativeAlternativePaymentDelegate,
-    private val eventDispatcher: POEventDispatcher = POEventDispatcher
+    private val eventDispatcher: POEventDispatcher = POEventDispatcher.instance
 ) {
 
     companion object {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/POSavedPaymentMethodsLauncher.kt
@@ -25,7 +25,7 @@ class POSavedPaymentMethodsLauncher private constructor(
     private val launcher: ActivityResultLauncher<POSavedPaymentMethodsConfiguration>,
     private val activityOptions: ActivityOptionsCompat,
     private val delegate: POSavedPaymentMethodsDelegate,
-    private val eventDispatcher: POEventDispatcher = POEventDispatcher
+    private val eventDispatcher: POEventDispatcher = POEventDispatcher.instance
 ) {
 
     companion object {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/savedpaymentmethods/SavedPaymentMethodsInteractor.kt
@@ -42,7 +42,7 @@ internal class SavedPaymentMethodsInteractor(
     private val configuration: POSavedPaymentMethodsConfiguration,
     private val invoicesService: POInvoicesService,
     private val customerTokensService: POCustomerTokensService,
-    private val eventDispatcher: POEventDispatcher = POEventDispatcher,
+    private val eventDispatcher: POEventDispatcher = POEventDispatcher.instance,
     private var logAttributes: Map<String, String> = logAttributes(
         invoiceId = configuration.invoiceRequest.invoiceId
     )


### PR DESCRIPTION
<!--- Ensure the title above is in the format <feat/fix/chore(<ticket_number>): <context of the change>-->

## Description
<!--- Provide some context in regard to this PR. -->
**Issue:**
`POCardTokenizationViewComponent` uses shared `POEventDispatcher`, so when multiple component instances are created they use the same event dispatcher, which causes all component's delegates to be notified about events, such as `processTokenizedCard()`.

**Fix:**
* `POCardTokenizationViewComponent` creates its own instance of `POEventDispatcher`, so events will be sent only to its delegate.
* Shared event dispatcher provided by `POEventDispatcher.instance`. Updated all usages.

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
https://checkout.atlassian.net/browse/POM-521
