### PR TITLE
fix(ad-hoc): setSendToExternalDefaultHandlerEnabled(true) for CustomTabsIntent

### DIFF
--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabAuthorizationActivity.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabAuthorizationActivity.kt
@@ -140,6 +140,7 @@ class POCustomTabAuthorizationActivity : AppCompatActivity() {
             .setStartAnimations(this, R.anim.po_slide_in_right, R.anim.po_slide_out_left)
             .setExitAnimations(this, R.anim.po_slide_in_left, R.anim.po_slide_out_right)
             .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
+            .setSendToExternalDefaultHandlerEnabled(true)
             .build()
             .also {
                 it.intent.setPackage(CHROME_PACKAGE)


### PR DESCRIPTION
`setSendToExternalDefaultHandlerEnabled(true)` for CustomTabsIntent:
[Open links in Android apps with Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/guide-warmup-prefetch#open_links_in_android_apps)