### PR TITLE
fix(ad-hoc): Remove return URI validation in Custom Tab

### DIFF
--- a/sdk/src/main/kotlin/com/processout/sdk/ui/apm/POAlternativePaymentMethodCustomTabLauncher.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/apm/POAlternativePaymentMethodCustomTabLauncher.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.ActivityResultLauncher
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import com.processout.sdk.api.ProcessOut
 import com.processout.sdk.api.model.request.POAlternativePaymentMethodRequest
@@ -147,7 +148,6 @@ class POAlternativePaymentMethodCustomTabLauncher private constructor(
             customTabLauncher.launch(
                 POCustomTabConfiguration(
                     uri = uri,
-                    returnUri = Uri.parse(returnUrl),
                     timeoutSeconds = null
                 )
             )
@@ -157,8 +157,8 @@ class POAlternativePaymentMethodCustomTabLauncher private constructor(
                 POWebViewConfiguration(
                     uri = uri,
                     returnUris = listOf(
-                        Uri.parse(ApiConstants.CHECKOUT_RETURN_URL),
-                        Uri.parse(returnUrl)
+                        ApiConstants.CHECKOUT_RETURN_URL.toUri(),
+                        returnUrl.toUri()
                     ),
                     sdkVersion = ProcessOut.VERSION,
                     timeoutSeconds = null

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/threeds/PO3DSRedirectCustomTabLauncher.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/threeds/PO3DSRedirectCustomTabLauncher.kt
@@ -1,7 +1,7 @@
 package com.processout.sdk.ui.threeds
 
-import android.net.Uri
 import androidx.activity.ComponentActivity
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import com.processout.sdk.api.ProcessOut
 import com.processout.sdk.api.model.threeds.PO3DSRedirect
@@ -75,8 +75,8 @@ class PO3DSRedirectCustomTabLauncher private constructor(
         }
 
         val delegate: WebAuthorizationDelegate = ThreeDSRedirectWebAuthorizationDelegate(
-            Uri.parse(redirect.url.toString()),
-            callback
+            uri = redirect.url.toString().toUri(),
+            callback = callback
         )
         delegateCache.delegate = delegate
 
@@ -84,7 +84,6 @@ class PO3DSRedirectCustomTabLauncher private constructor(
             contract.startActivity(
                 POCustomTabConfiguration(
                     uri = delegate.uri,
-                    returnUri = Uri.parse(returnUrl),
                     timeoutSeconds = redirect.timeoutSeconds,
                     resultApi = POActivityResultApi.Dispatcher
                 )
@@ -95,8 +94,8 @@ class PO3DSRedirectCustomTabLauncher private constructor(
                 POWebViewConfiguration(
                     uri = delegate.uri,
                     returnUris = listOf(
-                        Uri.parse(ApiConstants.CHECKOUT_RETURN_URL),
-                        Uri.parse(returnUrl)
+                        ApiConstants.CHECKOUT_RETURN_URL.toUri(),
+                        returnUrl.toUri()
                     ),
                     sdkVersion = ProcessOut.VERSION,
                     timeoutSeconds = redirect.timeoutSeconds,

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationViewModel.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/CustomTabAuthorizationViewModel.kt
@@ -7,8 +7,6 @@ import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.savedstate.SavedStateRegistryOwner
-import com.processout.sdk.core.POFailure
-import com.processout.sdk.core.ProcessOutActivityResult
 import com.processout.sdk.core.logger.POLogger
 import com.processout.sdk.ui.web.customtab.CustomTabAuthorizationUiState.*
 import com.processout.sdk.ui.web.customtab.POCustomTabAuthorizationActivityContract.Companion.EXTRA_FORCE_FINISH
@@ -65,23 +63,9 @@ internal class CustomTabAuthorizationViewModel private constructor(
         }
         val returnUri = intent.data
         if (returnUri != null) {
+            POLogger.info("Custom Chrome Tabs has been redirected to return URI: %s", returnUri)
             timeoutHandler.removeCallbacks(cancellationRunnable)
-            if (returnUri.scheme == configuration.returnUri.scheme &&
-                returnUri.host == configuration.returnUri.host &&
-                returnUri.path == configuration.returnUri.path
-            ) {
-                POLogger.info("Custom Chrome Tabs has been redirected to return URI: %s", returnUri)
-                savedState[KEY_SAVED_STATE] = Success(returnUri)
-            } else {
-                val errorMessage = "Unexpected Custom Chrome Tabs redirect to URI: $returnUri"
-                POLogger.error(errorMessage)
-                savedState[KEY_SAVED_STATE] = Failure(
-                    ProcessOutActivityResult.Failure(
-                        code = POFailure.Code.Internal(),
-                        message = errorMessage
-                    )
-                )
-            }
+            savedState[KEY_SAVED_STATE] = Success(returnUri)
             return
         }
         when (uiState) {

--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabConfiguration.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabConfiguration.kt
@@ -11,7 +11,6 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class POCustomTabConfiguration(
     val uri: Uri,
-    val returnUri: Uri,
     val timeoutSeconds: Int?,
     val resultApi: POActivityResultApi = POActivityResultApi.Android
 ) : Parcelable


### PR DESCRIPTION
Remove unnecessary return URI validation in Custom Tab. Return URI is set by intent filters in redirect activity, so they are always explicit and valid. Also there can be multiple intent filters, so it allows to support such configuration.