### PR TITLE
feat(ad-hoc): Dynamic checkout improvements

### DIFF
--- a/example/src/main/kotlin/com/processout/example/ui/screen/card/payment/CardPaymentFragment.kt
+++ b/example/src/main/kotlin/com/processout/example/ui/screen/card/payment/CardPaymentFragment.kt
@@ -30,6 +30,7 @@ import com.processout.sdk.netcetera.threeds.PONetcetera3DS2ServiceConfiguration
 import com.processout.sdk.ui.card.tokenization.POCardTokenizationActivity
 import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration
 import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration.CardScannerConfiguration
+import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration.SavingConfiguration
 import com.processout.sdk.ui.card.tokenization.POCardTokenizationLauncher
 import com.processout.sdk.ui.shared.view.dialog.POAlertDialog
 import com.processout.sdk.ui.threeds.PO3DSRedirectCustomTabLauncher
@@ -95,9 +96,9 @@ class CardPaymentFragment : BaseFragment<FragmentCardPaymentBinding>(
 
     private fun launchTokenization() {
         launcher.launch(
-            POCardTokenizationConfiguration(
+            configuration = POCardTokenizationConfiguration(
                 cardScanner = CardScannerConfiguration(),
-                savingAllowed = true
+                saving = SavingConfiguration()
             )
         )
     }

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/response/InvoiceAuthorizationResponse.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/response/InvoiceAuthorizationResponse.kt
@@ -1,22 +1,51 @@
 package com.processout.sdk.api.model.response
 
+import com.processout.sdk.core.annotation.ProcessOutInternalApi
+import com.processout.sdk.core.util.findBy
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 internal data class InvoiceAuthorizationResponse(
+    @Json(name = "outcome")
+    val rawOutcome: String,
     @Json(name = "customer_action")
     val customerAction: CustomerAction?,
     @Json(name = "customer_token_id")
     val customerTokenId: String?
-)
+) {
+
+    val outcome: POInvoiceAuthorizationOutcome
+        get() = POInvoiceAuthorizationOutcome::rawValue.findBy(rawOutcome) ?: POInvoiceAuthorizationOutcome.UNKNOWN
+}
 
 /**
  * Invoice authorization response.
  *
+ * @param[outcome] Invoice authorization outcome.
  * @param[customerTokenId] Optional customer token ID.
  * Available if invoice was authorized with `saveSource` flag set to `true` and implementation was able to tokenize the source.
  */
 data class POInvoiceAuthorizationResponse(
+    val outcome: POInvoiceAuthorizationOutcome,
     val customerTokenId: String?
 )
+
+/**
+ * Invoice authorization outcome determined by the request and the current transaction status.
+ */
+@JsonClass(generateAdapter = false)
+enum class POInvoiceAuthorizationOutcome(val rawValue: String) {
+    /** Pending operation. */
+    PENDING("pending"),
+
+    /** Successful operation. */
+    SUCCESS("success"),
+
+    /**
+     * Placeholder that allows adding additional cases while staying backward compatible.
+     * __Warning:__ Do not match this case directly, use _when-else_ instead.
+     */
+    @ProcessOutInternalApi
+    UNKNOWN(String())
+}

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/response/InvoiceAuthorizationResponse.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/response/InvoiceAuthorizationResponse.kt
@@ -6,5 +6,17 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 internal data class InvoiceAuthorizationResponse(
     @Json(name = "customer_action")
-    val customerAction: CustomerAction?
+    val customerAction: CustomerAction?,
+    @Json(name = "customer_token_id")
+    val customerTokenId: String?
+)
+
+/**
+ * Invoice authorization response.
+ *
+ * @param[customerTokenId] Optional customer token ID.
+ * Available if invoice was authorized with `saveSource` flag set to `true` and implementation was able to tokenize the source.
+ */
+data class POInvoiceAuthorizationResponse(
+    val customerTokenId: String?
 )

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/response/InvoiceResponse.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/response/InvoiceResponse.kt
@@ -156,6 +156,8 @@ sealed class PODynamicCheckoutPaymentMethod {
      * @param[cvcRequired] Defines whether the card CVC should be collected.
      * @param[cardholderNameRequired] Defines whether the cardholder name should be collected.
      * @param[schemeSelectionAllowed] Defines whether the user will be asked to select the scheme if co-scheme is available.
+     * @param[schemeSelectionDefaultOrder] Schemes selection preferred order.
+     * When cards with multiple supported schemes are detected, the first matching scheme is preselected.
      * @param[billingAddress] Card billing address configuration.
      * @param[savingAllowed] Defines whether saving of the payment method is allowed for future payments.
      */
@@ -167,6 +169,8 @@ sealed class PODynamicCheckoutPaymentMethod {
         val cardholderNameRequired: Boolean,
         @Json(name = "scheme_selection_allowed")
         val schemeSelectionAllowed: Boolean,
+        @Json(name = "scheme_selection_default_order")
+        val schemeSelectionDefaultOrder: List<String>?,
         @Json(name = "billing_address")
         val billingAddress: BillingAddressConfiguration,
         @Json(name = "saving_allowed")

--- a/sdk/src/main/kotlin/com/processout/sdk/api/model/response/InvoiceResponse.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/model/response/InvoiceResponse.kt
@@ -158,6 +158,8 @@ sealed class PODynamicCheckoutPaymentMethod {
      * @param[schemeSelectionAllowed] Defines whether the user will be asked to select the scheme if co-scheme is available.
      * @param[schemeSelectionDefaultOrder] Schemes selection preferred order.
      * When cards with multiple supported schemes are detected, the first matching scheme is preselected.
+     * @param[restrictToIins] Restrict card schemes to the ones with IINs in the set.
+     * @param[restrictToSchemes] Restrict card schemes to the ones in the set.
      * @param[billingAddress] Card billing address configuration.
      * @param[savingAllowed] Defines whether saving of the payment method is allowed for future payments.
      */
@@ -171,6 +173,10 @@ sealed class PODynamicCheckoutPaymentMethod {
         val schemeSelectionAllowed: Boolean,
         @Json(name = "scheme_selection_default_order")
         val schemeSelectionDefaultOrder: List<String>?,
+        @Json(name = "restrict_to_iins")
+        val restrictToIins: Set<String>?,
+        @Json(name = "restrict_to_schemes")
+        val restrictToSchemes: Set<String>?,
         @Json(name = "billing_address")
         val billingAddress: BillingAddressConfiguration,
         @Json(name = "saving_allowed")

--- a/sdk/src/main/kotlin/com/processout/sdk/api/service/DefaultInvoicesService.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/service/DefaultInvoicesService.kt
@@ -175,6 +175,7 @@ internal class DefaultInvoicesService(
                         if (response.customerAction == null) {
                             threeDSService.cleanup()
                             val authorizationResponse = POInvoiceAuthorizationResponse(
+                                outcome = response.outcome,
                                 customerTokenId = response.customerTokenId
                             )
                             return@fold ProcessOutResult.Success(authorizationResponse)

--- a/sdk/src/main/kotlin/com/processout/sdk/api/service/DefaultInvoicesService.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/service/DefaultInvoicesService.kt
@@ -8,10 +8,7 @@ import com.processout.sdk.api.model.request.POInvoiceRequest
 import com.processout.sdk.api.model.request.PONativeAlternativePaymentMethodRequest
 import com.processout.sdk.api.model.request.napm.v2.PONativeAlternativePaymentAuthorizationRequest
 import com.processout.sdk.api.model.request.napm.v2.PONativeAlternativePaymentUrlResolutionRequest
-import com.processout.sdk.api.model.response.POInvoice
-import com.processout.sdk.api.model.response.PONativeAlternativePaymentMethod
-import com.processout.sdk.api.model.response.PONativeAlternativePaymentMethodCapture
-import com.processout.sdk.api.model.response.PONativeAlternativePaymentMethodTransactionDetails
+import com.processout.sdk.api.model.response.*
 import com.processout.sdk.api.model.response.napm.v2.PONativeAlternativePaymentAuthorizationResponse
 import com.processout.sdk.api.model.response.napm.v2.PONativeAlternativePaymentUrlResolutionResponse
 import com.processout.sdk.api.repository.InvoicesRepository
@@ -125,6 +122,67 @@ internal class DefaultInvoicesService(
                             .fold(
                                 onSuccess = { newSource ->
                                     authorize(
+                                        request.copy(source = newSource),
+                                        threeDSService
+                                    )
+                                },
+                                onFailure = { failure ->
+                                    POLogger.warn(
+                                        message = "Failed to authorize invoice: %s", failure,
+                                        attributes = logAttributes
+                                    )
+                                    threeDSService.cleanup()
+                                    failure
+                                }
+                            )
+                    },
+                    onFailure = { failure ->
+                        POLogger.warn(
+                            message = "Failed to authorize invoice: %s", failure,
+                            attributes = logAttributes
+                        )
+                        threeDSService.cleanup()
+                        failure
+                    }
+                )
+        } catch (e: CancellationException) {
+            coroutineScope {
+                val failure = ProcessOutResult.Failure(
+                    code = Cancelled,
+                    message = e.message,
+                    cause = e
+                )
+                POLogger.info(
+                    message = "Invoice authorization has been cancelled: %s", failure,
+                    attributes = logAttributes
+                )
+                threeDSService.cleanup()
+                ensureActive()
+                failure
+            }
+        }
+    }
+
+    override suspend fun authorizeV2(
+        request: POInvoiceAuthorizationRequest,
+        threeDSService: PO3DSService
+    ): ProcessOutResult<POInvoiceAuthorizationResponse> {
+        val logAttributes = mapOf(POLogAttribute.INVOICE_ID to request.invoiceId)
+        return try {
+            repository.authorizeInvoice(request)
+                .fold(
+                    onSuccess = { response ->
+                        if (response.customerAction == null) {
+                            threeDSService.cleanup()
+                            val authorizationResponse = POInvoiceAuthorizationResponse(
+                                customerTokenId = response.customerTokenId
+                            )
+                            return@fold ProcessOutResult.Success(authorizationResponse)
+                        }
+                        customerActionsService.handle(response.customerAction, threeDSService)
+                            .fold(
+                                onSuccess = { newSource ->
+                                    authorizeV2(
                                         request.copy(source = newSource),
                                         threeDSService
                                     )

--- a/sdk/src/main/kotlin/com/processout/sdk/api/service/POInvoicesService.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/api/service/POInvoicesService.kt
@@ -6,10 +6,7 @@ import com.processout.sdk.api.model.request.POInvoiceRequest
 import com.processout.sdk.api.model.request.PONativeAlternativePaymentMethodRequest
 import com.processout.sdk.api.model.request.napm.v2.PONativeAlternativePaymentAuthorizationRequest
 import com.processout.sdk.api.model.request.napm.v2.PONativeAlternativePaymentUrlResolutionRequest
-import com.processout.sdk.api.model.response.POInvoice
-import com.processout.sdk.api.model.response.PONativeAlternativePaymentMethod
-import com.processout.sdk.api.model.response.PONativeAlternativePaymentMethodCapture
-import com.processout.sdk.api.model.response.PONativeAlternativePaymentMethodTransactionDetails
+import com.processout.sdk.api.model.response.*
 import com.processout.sdk.api.model.response.napm.v2.PONativeAlternativePaymentAuthorizationResponse
 import com.processout.sdk.api.model.response.napm.v2.PONativeAlternativePaymentUrlResolutionResponse
 import com.processout.sdk.core.ProcessOutCallback
@@ -66,6 +63,15 @@ interface POInvoicesService {
         request: POInvoiceAuthorizationRequest,
         threeDSService: PO3DSService
     ): ProcessOutResult<Unit>
+
+    /**
+     * Authorize invoice with the given request and 3DS service implementation.
+     * Provides the result with [POInvoiceAuthorizationResponse].
+     */
+    suspend fun authorizeV2(
+        request: POInvoiceAuthorizationRequest,
+        threeDSService: PO3DSService
+    ): ProcessOutResult<POInvoiceAuthorizationResponse>
 
     /**
      * Authorize invoice with the given request.

--- a/sdk/src/main/res/values-ar/strings.xml
+++ b/sdk/src/main/res/values-ar/strings.xml
@@ -5,6 +5,7 @@
 
     <!-- Dynamic Checkout -->
     <string name="po_dynamic_checkout_express_checkout">الدفع السريع</string>
+    <string name="po_dynamic_checkout_regular_checkout">طرق دفع أخرى</string>
     <string name="po_dynamic_checkout_button_pay">ادفع</string>
     <string name="po_dynamic_checkout_button_cancel">إلغاء</string>
     <string name="po_dynamic_checkout_save_payment_method">حِفْظُ هذِهِ الطَّريقَةِ لِلدَّفْعِ في المُستَقبَلِ</string>

--- a/sdk/src/main/res/values-fr/strings.xml
+++ b/sdk/src/main/res/values-fr/strings.xml
@@ -5,6 +5,7 @@
 
     <!-- Dynamic Checkout -->
     <string name="po_dynamic_checkout_express_checkout">Paiement express</string>
+    <string name="po_dynamic_checkout_regular_checkout">Autres modes de paiement</string>
     <string name="po_dynamic_checkout_button_pay">Payer</string>
     <string name="po_dynamic_checkout_button_cancel">Annuler</string>
     <string name="po_dynamic_checkout_save_payment_method">Enregistrer cette méthode pour les paiements futurs</string>

--- a/sdk/src/main/res/values-pl/strings.xml
+++ b/sdk/src/main/res/values-pl/strings.xml
@@ -5,6 +5,7 @@
 
     <!-- Dynamic Checkout -->
     <string name="po_dynamic_checkout_express_checkout">Szybka płatność</string>
+    <string name="po_dynamic_checkout_regular_checkout">Inne metody płatności</string>
     <string name="po_dynamic_checkout_button_pay">Zapłać</string>
     <string name="po_dynamic_checkout_button_cancel">Anuluj</string>
     <string name="po_dynamic_checkout_save_payment_method">Zapisz tę metodę płatności na przyszłe płatności</string>

--- a/sdk/src/main/res/values-pt/strings.xml
+++ b/sdk/src/main/res/values-pt/strings.xml
@@ -5,6 +5,7 @@
 
     <!-- Dynamic Checkout -->
     <string name="po_dynamic_checkout_express_checkout">Pagamento expresso</string>
+    <string name="po_dynamic_checkout_regular_checkout">Outras formas de pagamento</string>
     <string name="po_dynamic_checkout_button_pay">Pagar</string>
     <string name="po_dynamic_checkout_button_cancel">Cancelar</string>
     <string name="po_dynamic_checkout_save_payment_method">Guardar este método para futuros pagamentos</string>

--- a/sdk/src/main/res/values/strings.xml
+++ b/sdk/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
 
     <!-- Dynamic Checkout -->
     <string name="po_dynamic_checkout_express_checkout">Express checkout</string>
+    <string name="po_dynamic_checkout_regular_checkout">Other payment methods</string>
     <string name="po_dynamic_checkout_button_pay">Pay</string>
     <string name="po_dynamic_checkout_button_cancel">Cancel</string>
     <string name="po_dynamic_checkout_save_payment_method">Save this method for future payments</string>

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationBottomSheet.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationBottomSheet.kt
@@ -25,7 +25,6 @@ import com.processout.sdk.ui.card.tokenization.CardTokenizationCompletion.Succes
 import com.processout.sdk.ui.card.tokenization.CardTokenizationEvent.CardScannerResult
 import com.processout.sdk.ui.card.tokenization.CardTokenizationEvent.Dismiss
 import com.processout.sdk.ui.card.tokenization.CardTokenizationSideEffect.CardScanner
-import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration.Button
 import com.processout.sdk.ui.card.tokenization.screen.CardTokenizationScreen
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
 import com.processout.sdk.ui.shared.component.displayCutoutHeight
@@ -60,7 +59,7 @@ internal class CardTokenizationBottomSheet : BaseBottomSheetDialogFragment<POCar
         super.onAttach(context)
         @Suppress("DEPRECATION")
         configuration = arguments?.getParcelable(EXTRA_CONFIGURATION)
-            ?: POCardTokenizationConfiguration(submitButton = Button())
+            ?: POCardTokenizationConfiguration(saving = null)
         cardScannerLauncher = POCardScannerLauncher.create(
             from = this,
             callback = { result ->

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
@@ -149,7 +149,7 @@ internal class CardTokenizationInteractor(
         saveCardField = Field(
             id = FieldId.SAVE_CARD,
             value = TextFieldValue(text = "false"),
-            shouldCollect = configuration.savingAllowed
+            shouldCollect = configuration.saving != null
         ),
         focusedFieldId = CardFieldId.NUMBER,
         pendingFocusedFieldId = null,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
@@ -139,25 +139,30 @@ internal class CardTokenizationInteractor(
         latestShouldContinueRequest = null
     }
 
-    private fun initState() = CardTokenizationInteractorState(
-        cardFields = cardFields(),
-        addressFields = emptyList(),
-        preferredSchemeField = Field(
-            id = FieldId.PREFERRED_SCHEME,
-            shouldCollect = false
-        ),
-        saveCardField = Field(
-            id = FieldId.SAVE_CARD,
-            value = TextFieldValue(text = "false"),
-            enabled = configuration.saving?.required != true,
-            shouldCollect = configuration.saving != null
-        ),
-        focusedFieldId = CardFieldId.NUMBER,
-        pendingFocusedFieldId = null,
-        primaryActionId = ActionId.SUBMIT,
-        secondaryActionId = ActionId.CANCEL,
-        cardScannerActionId = ActionId.CARD_SCANNER
-    )
+    private fun initState(): CardTokenizationInteractorState {
+        val saveCardFieldValue: Boolean = configuration.saving?.let {
+            it.required || it.enabledByDefault
+        } ?: false
+        return CardTokenizationInteractorState(
+            cardFields = cardFields(),
+            addressFields = emptyList(),
+            preferredSchemeField = Field(
+                id = FieldId.PREFERRED_SCHEME,
+                shouldCollect = false
+            ),
+            saveCardField = Field(
+                id = FieldId.SAVE_CARD,
+                value = TextFieldValue(text = saveCardFieldValue.toString()),
+                enabled = configuration.saving?.required != true,
+                shouldCollect = configuration.saving != null
+            ),
+            focusedFieldId = CardFieldId.NUMBER,
+            pendingFocusedFieldId = null,
+            primaryActionId = ActionId.SUBMIT,
+            secondaryActionId = ActionId.CANCEL,
+            cardScannerActionId = ActionId.CARD_SCANNER
+        )
+    }
 
     private fun cardFields(): List<Field> = mutableListOf(
         Field(id = CardFieldId.NUMBER),
@@ -304,7 +309,7 @@ internal class CardTokenizationInteractor(
                     field.copy(enabled = enabled)
                 },
                 preferredSchemeField = it.preferredSchemeField.copy(enabled = enabled),
-                saveCardField = it.saveCardField.copy(enabled = enabled)
+                saveCardField = it.saveCardField.copy(enabled = configuration.saving?.required != true)
             )
         }
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
@@ -149,6 +149,7 @@ internal class CardTokenizationInteractor(
         saveCardField = Field(
             id = FieldId.SAVE_CARD,
             value = TextFieldValue(text = "false"),
+            enabled = configuration.saving?.required != true,
             shouldCollect = configuration.saving != null
         ),
         focusedFieldId = CardFieldId.NUMBER,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
@@ -25,7 +25,8 @@ import kotlinx.parcelize.Parcelize
  * @param[preferredScheme] Preferred scheme selection configuration.
  * Shows scheme selection if co-scheme is available. Use _null_ to hide.
  * @param[billingAddress] Allows to customize the collection of billing address.
- * @param[savingAllowed] Displays checkbox that allows to save the card details for future payments.
+ * @param[saving] Card saving configuration. Displays checkbox that allows to save the card details for future payments.
+ * Use _null_ to hide, this is a default behaviour.
  * @param[submitButton] Submit button configuration.
  * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
  * @param[bottomSheet] Specifies bottom sheet configuration. By default is [WrapContent] and non-expandable.
@@ -40,7 +41,7 @@ data class POCardTokenizationConfiguration(
     val cardScanner: CardScannerConfiguration? = null,
     val preferredScheme: PreferredSchemeConfiguration? = PreferredSchemeConfiguration(),
     val billingAddress: BillingAddressConfiguration = BillingAddressConfiguration(),
-    val savingAllowed: Boolean = false,
+    val saving: SavingConfiguration? = null,
     val submitButton: Button = Button(),
     val cancelButton: CancelButton? = CancelButton(),
     val bottomSheet: POBottomSheetConfiguration = POBottomSheetConfiguration(
@@ -51,6 +52,53 @@ data class POCardTokenizationConfiguration(
     val style: Style? = null,
     internal val _submitButton: Button? = submitButton
 ) : Parcelable {
+
+    /**
+     * Defines card tokenization configuration.
+     *
+     * @param[title] Custom title.
+     * @param[cvcRequired] Specifies whether the CVC field should be displayed. Default value is _true_.
+     * @param[cardholderNameRequired] Specifies whether the cardholder name field should be displayed. Default value is _true_.
+     * @param[cardScanner] Card scanner configuration. Use _null_ to hide, this is a default behaviour.
+     * @param[preferredScheme] Preferred scheme selection configuration.
+     * Shows scheme selection if co-scheme is available. Use _null_ to hide.
+     * @param[billingAddress] Allows to customize the collection of billing address.
+     * @param[savingAllowed] Displays checkbox that allows to save the card details for future payments.
+     * @param[submitButton] Submit button configuration.
+     * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
+     * @param[bottomSheet] Specifies bottom sheet configuration. By default is [WrapContent] and non-expandable.
+     * @param[metadata] Metadata related to the card.
+     * @param[style] Custom style.
+     */
+    @Deprecated(message = "Use alternative constructor.")
+    constructor(
+        title: String? = null,
+        cvcRequired: Boolean = true,
+        cardholderNameRequired: Boolean = true,
+        cardScanner: CardScannerConfiguration? = null,
+        preferredScheme: PreferredSchemeConfiguration? = PreferredSchemeConfiguration(),
+        billingAddress: BillingAddressConfiguration = BillingAddressConfiguration(),
+        savingAllowed: Boolean = false,
+        submitButton: Button = Button(),
+        cancelButton: CancelButton? = CancelButton(),
+        bottomSheet: POBottomSheetConfiguration = POBottomSheetConfiguration(
+            height = WrapContent,
+            expandable = false
+        ),
+        metadata: Map<String, String>? = null,
+        style: Style? = null
+    ) : this(
+        title = title,
+        cvcRequired = cvcRequired,
+        cardholderNameRequired = cardholderNameRequired,
+        billingAddress = billingAddress,
+        saving = if (savingAllowed) SavingConfiguration() else null,
+        submitButton = submitButton,
+        cancelButton = cancelButton,
+        bottomSheet = bottomSheet,
+        metadata = metadata,
+        style = style
+    )
 
     /**
      * Defines card tokenization configuration.
@@ -152,6 +200,18 @@ data class POCardTokenizationConfiguration(
             Full
         }
     }
+
+    /**
+     * Card saving configuration.
+     *
+     * @param[enabledByDefault] Initial selection state.
+     * @param[required] If `true`, saving is enforced and cannot be disabled by the user.
+     */
+    @Parcelize
+    data class SavingConfiguration(
+        val enabledByDefault: Boolean = false,
+        val required: Boolean = false
+    ) : Parcelable
 
     /**
      * Button configuration.

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/component/POCardTokenizationViewComponent.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/component/POCardTokenizationViewComponent.kt
@@ -147,7 +147,7 @@ class POCardTokenizationViewComponent private constructor(
                 cardScanner = cardScanner,
                 preferredScheme = preferredScheme,
                 billingAddress = billingAddress,
-                savingAllowed = savingAllowed,
+                saving = saving,
                 submitButton = Button(),
                 cancelButton = cancelButton,
                 bottomSheet = POBottomSheetConfiguration(

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/component/POCardTokenizationViewComponentConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/component/POCardTokenizationViewComponentConfiguration.kt
@@ -11,7 +11,8 @@ import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration.*
  * @param[preferredScheme] Preferred scheme selection configuration.
  * Shows scheme selection if co-scheme is available. Use _null_ to hide.
  * @param[billingAddress] Allows to customize the collection of billing address.
- * @param[savingAllowed] Displays checkbox that allows to save the card details for future payments.
+ * @param[saving] Card saving configuration. Displays checkbox that allows to save the card details for future payments.
+ * Use _null_ to hide, this is a default behaviour.
  * @param[submitButton] Submit button configuration. Use _null_ to hide.
  * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
  * @param[metadata] Metadata related to the card.
@@ -23,9 +24,50 @@ data class POCardTokenizationViewComponentConfiguration(
     val cardScanner: CardScannerConfiguration? = null,
     val preferredScheme: PreferredSchemeConfiguration? = PreferredSchemeConfiguration(),
     val billingAddress: BillingAddressConfiguration = BillingAddressConfiguration(),
-    val savingAllowed: Boolean = false,
+    val saving: SavingConfiguration? = null,
     val submitButton: Button? = Button(),
     val cancelButton: CancelButton? = CancelButton(),
     val metadata: Map<String, String>? = null,
     val style: Style? = null
-)
+) {
+
+    /**
+     * Defines card tokenization view component configuration.
+     *
+     * @param[cvcRequired] Specifies whether the CVC field should be displayed. Default value is _true_.
+     * @param[cardholderNameRequired] Specifies whether the cardholder name field should be displayed. Default value is _true_.
+     * @param[cardScanner] Card scanner configuration. Use _null_ to hide, this is a default behaviour.
+     * @param[preferredScheme] Preferred scheme selection configuration.
+     * Shows scheme selection if co-scheme is available. Use _null_ to hide.
+     * @param[billingAddress] Allows to customize the collection of billing address.
+     * @param[savingAllowed] Displays checkbox that allows to save the card details for future payments.
+     * @param[submitButton] Submit button configuration. Use _null_ to hide.
+     * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
+     * @param[metadata] Metadata related to the card.
+     * @param[style] Allows to customize the look and feel.
+     */
+    @Deprecated(message = "Use alternative constructor.")
+    constructor(
+        cvcRequired: Boolean = true,
+        cardholderNameRequired: Boolean = true,
+        cardScanner: CardScannerConfiguration? = null,
+        preferredScheme: PreferredSchemeConfiguration? = PreferredSchemeConfiguration(),
+        billingAddress: BillingAddressConfiguration = BillingAddressConfiguration(),
+        savingAllowed: Boolean = false,
+        submitButton: Button? = Button(),
+        cancelButton: CancelButton? = CancelButton(),
+        metadata: Map<String, String>? = null,
+        style: Style? = null
+    ) : this(
+        cvcRequired = cvcRequired,
+        cardholderNameRequired = cardholderNameRequired,
+        cardScanner = cardScanner,
+        preferredScheme = preferredScheme,
+        billingAddress = billingAddress,
+        saving = if (savingAllowed) SavingConfiguration() else null,
+        submitButton = submitButton,
+        cancelButton = cancelButton,
+        metadata = metadata,
+        style = style
+    )
+}

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/screen/CardTokenizationContent.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/screen/CardTokenizationContent.kt
@@ -355,6 +355,7 @@ private fun CheckboxField(
         },
         modifier = modifier,
         checkboxStyle = style,
+        enabled = state.enabled,
         isError = state.isError
     )
 }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -39,6 +39,7 @@ import com.processout.sdk.core.onSuccess
 import com.processout.sdk.ui.base.BaseInteractor
 import com.processout.sdk.ui.card.tokenization.*
 import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration.BillingAddressConfiguration.CollectionMode
+import com.processout.sdk.ui.card.tokenization.delegate.CardTokenizationPreferredSchemeResponse
 import com.processout.sdk.ui.card.tokenization.delegate.CardTokenizationProcessingRequest
 import com.processout.sdk.ui.card.tokenization.delegate.CardTokenizationShouldContinueRequest
 import com.processout.sdk.ui.card.tokenization.delegate.toResponse
@@ -1088,6 +1089,27 @@ internal class DynamicCheckoutInteractor(
     }
 
     private fun dispatchEvents() {
+        eventDispatcher.subscribeForResponse<DynamicCheckoutCardPreferredSchemeResponse>(
+            coroutineScope = interactorScope
+        ) { response ->
+            activePaymentMethod()?.let { paymentMethod ->
+                if (paymentMethod is Card) {
+                    interactorScope.launch {
+                        val schemeSelectionDefaultOrder = paymentMethod.configuration.schemeSelectionDefaultOrder
+                        val issuerInformation = response.issuerInformation
+                        val preferredScheme = response.preferredScheme
+                            ?: schemeSelectionDefaultOrder?.firstOrNull { scheme ->
+                                scheme == issuerInformation.scheme || scheme == issuerInformation.coScheme
+                            } ?: issuerInformation.scheme
+                        val cardResponse = CardTokenizationPreferredSchemeResponse(
+                            uuid = response.uuid,
+                            preferredScheme = preferredScheme
+                        )
+                        eventDispatcher.send(cardResponse)
+                    }
+                }
+            }
+        }
         eventDispatcher.subscribeForRequest<CardTokenizationShouldContinueRequest>(
             coroutineScope = interactorScope
         ) { request ->

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -1089,6 +1089,11 @@ internal class DynamicCheckoutInteractor(
     }
 
     private fun dispatchEvents() {
+        dispatchCardTokenizationEvents()
+        dispatchNativeAlternativePaymentEvents()
+    }
+
+    private fun dispatchCardTokenizationEvents() {
         eventDispatcher.subscribeForResponse<DynamicCheckoutCardPreferredSchemeResponse>(
             coroutineScope = interactorScope
         ) { response ->
@@ -1101,15 +1106,16 @@ internal class DynamicCheckoutInteractor(
                             ?: schemeSelectionDefaultOrder?.firstOrNull { scheme ->
                                 scheme == issuerInformation.scheme || scheme == issuerInformation.coScheme
                             } ?: issuerInformation.scheme
-                        val cardResponse = CardTokenizationPreferredSchemeResponse(
+                        val preferredSchemeResponse = CardTokenizationPreferredSchemeResponse(
                             uuid = response.uuid,
                             preferredScheme = preferredScheme
                         )
-                        eventDispatcher.send(cardResponse)
+                        eventDispatcher.send(preferredSchemeResponse)
                     }
                 }
             }
         }
+
         eventDispatcher.subscribeForRequest<CardTokenizationShouldContinueRequest>(
             coroutineScope = interactorScope
         ) { request ->
@@ -1118,6 +1124,17 @@ internal class DynamicCheckoutInteractor(
                 eventDispatcher.send(request.toResponse(shouldContinue))
             }
         }
+    }
+
+    private fun dispatchNativeAlternativePaymentEvents() {
+        eventDispatcher.subscribe<PONativeAlternativePaymentEvent>(
+            coroutineScope = interactorScope
+        ) { event ->
+            if (event is PONativeAlternativePaymentEvent.WillStart) {
+                _state.update { it.copy(processingPaymentMethod = _state.value.selectedPaymentMethod) }
+            }
+        }
+
         eventDispatcher.subscribeForRequest<NativeAlternativePaymentDefaultValuesRequest>(
             coroutineScope = interactorScope
         ) { request ->
@@ -1132,13 +1149,6 @@ internal class DynamicCheckoutInteractor(
                         eventDispatcher.send(defaultValuesRequest)
                     }
                 }
-            }
-        }
-        eventDispatcher.subscribe<PONativeAlternativePaymentEvent>(
-            coroutineScope = interactorScope
-        ) { event ->
-            if (event is PONativeAlternativePaymentEvent.WillStart) {
-                _state.update { it.copy(processingPaymentMethod = _state.value.selectedPaymentMethod) }
             }
         }
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -64,7 +64,6 @@ import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.*
 import com.processout.sdk.ui.napm.PONativeAlternativePaymentConfiguration.Flow
 import com.processout.sdk.ui.napm.delegate.v2.NativeAlternativePaymentDefaultValuesRequest
 import com.processout.sdk.ui.napm.delegate.v2.PONativeAlternativePaymentEvent
-import com.processout.sdk.ui.napm.delegate.v2.PONativeAlternativePaymentEvent.WillSubmitParameters
 import com.processout.sdk.ui.savedpaymentmethods.POSavedPaymentMethodsConfiguration
 import com.processout.sdk.ui.shared.extension.orElse
 import com.processout.sdk.ui.shared.state.FieldValue
@@ -1116,7 +1115,7 @@ internal class DynamicCheckoutInteractor(
         eventDispatcher.subscribe<PONativeAlternativePaymentEvent>(
             coroutineScope = interactorScope
         ) { event ->
-            if (event is WillSubmitParameters) {
+            if (event is PONativeAlternativePaymentEvent.WillStart) {
                 _state.update { it.copy(processingPaymentMethod = _state.value.selectedPaymentMethod) }
             }
         }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -291,9 +291,13 @@ internal class DynamicCheckoutInteractor(
                         gatewayConfigurationId = paymentMethod.configuration.gatewayConfigurationId,
                         redirectUrl = redirectUrl,
                         savePaymentMethodField = if (paymentMethod.configuration.savingAllowed) {
+                            val value: Boolean = configuration.saving?.let {
+                                it.required || it.enabledByDefault
+                            } ?: false
                             Field(
                                 id = FieldId.SAVE_PAYMENT_METHOD,
-                                value = TextFieldValue(text = "false")
+                                value = TextFieldValue(text = value.toString()),
+                                enabled = configuration.saving?.required != true
                             )
                         } else null,
                         display = paymentMethod.display,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -988,7 +988,7 @@ internal class DynamicCheckoutInteractor(
             POLogger.info("Authorizing the invoice.", attributes = logAttributes)
             val threeDSService = PODefaultProxy3DSService()
             val job = interactorScope.launch {
-                val result = invoicesService.authorize(
+                val result = invoicesService.authorizeV2(
                     request = response.request,
                     threeDSService = threeDSService
                 )
@@ -1008,7 +1008,7 @@ internal class DynamicCheckoutInteractor(
     private fun handleInvoiceAuthorization(
         state: DynamicCheckoutInteractorState,
         invoiceId: String,
-        result: ProcessOutResult<Unit>
+        result: ProcessOutResult<POInvoiceAuthorizationResponse>
     ) {
         if (invoiceId != state.invoice?.id) {
             return

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -39,10 +39,9 @@ import com.processout.sdk.core.onSuccess
 import com.processout.sdk.ui.base.BaseInteractor
 import com.processout.sdk.ui.card.tokenization.*
 import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration.BillingAddressConfiguration.CollectionMode
-import com.processout.sdk.ui.card.tokenization.delegate.CardTokenizationPreferredSchemeResponse
-import com.processout.sdk.ui.card.tokenization.delegate.CardTokenizationProcessingRequest
-import com.processout.sdk.ui.card.tokenization.delegate.CardTokenizationShouldContinueRequest
-import com.processout.sdk.ui.card.tokenization.delegate.toResponse
+import com.processout.sdk.ui.card.tokenization.delegate.*
+import com.processout.sdk.ui.card.tokenization.delegate.POCardTokenizationEligibility.Eligible
+import com.processout.sdk.ui.card.tokenization.delegate.POCardTokenizationEligibility.NotEligible
 import com.processout.sdk.ui.checkout.DynamicCheckoutCompletion.*
 import com.processout.sdk.ui.checkout.DynamicCheckoutEvent.*
 import com.processout.sdk.ui.checkout.DynamicCheckoutInteractorState.*
@@ -1094,6 +1093,47 @@ internal class DynamicCheckoutInteractor(
     }
 
     private fun dispatchCardTokenizationEvents() {
+        eventDispatcher.subscribeForResponse<DynamicCheckoutCardEligibilityResponse>(
+            coroutineScope = interactorScope
+        ) { response ->
+            activePaymentMethod()?.let { paymentMethod ->
+                if (paymentMethod is Card) {
+                    interactorScope.launch {
+                        val eligibilityByIins: POCardTokenizationEligibility? =
+                            paymentMethod.configuration.restrictToIins?.let { eligibleIins ->
+                                val isEligible = eligibleIins.any { eligibleIin ->
+                                    response.iin.startsWith(eligibleIin)
+                                }
+                                if (isEligible) Eligible() else NotEligible()
+                            }
+                        val eligibilityBySchemes: POCardTokenizationEligibility? =
+                            paymentMethod.configuration.restrictToSchemes?.let { eligibleSchemes ->
+                                val scheme = response.issuerInformation.scheme
+                                val coScheme = response.issuerInformation.coScheme
+                                val isSchemeEligible = scheme in eligibleSchemes
+                                val isCoSchemeEligible = coScheme in eligibleSchemes
+                                when {
+                                    coScheme == null -> if (isSchemeEligible) Eligible(scheme) else NotEligible()
+                                    !isSchemeEligible && !isCoSchemeEligible -> NotEligible()
+                                    isSchemeEligible && !isCoSchemeEligible -> Eligible(scheme)
+                                    !isSchemeEligible -> Eligible(coScheme)
+                                    else -> Eligible()
+                                }
+                            }
+                        val eligibility = response.eligibility
+                            ?: eligibilityByIins
+                            ?: eligibilityBySchemes
+                            ?: Eligible()
+                        val eligibilityResponse = CardTokenizationEligibilityResponse(
+                            uuid = response.uuid,
+                            eligibility = eligibility
+                        )
+                        eventDispatcher.send(eligibilityResponse)
+                    }
+                }
+            }
+        }
+
         eventDispatcher.subscribeForResponse<DynamicCheckoutCardPreferredSchemeResponse>(
             coroutineScope = interactorScope
         ) { response ->

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -1013,6 +1013,17 @@ internal class DynamicCheckoutInteractor(
         if (invoiceId != state.invoice?.id) {
             return
         }
+        result.onSuccess { response ->
+            val customerTokenId = response.customerTokenId
+            val paymentMethod = state.processingPaymentMethod
+            if (customerTokenId != null && paymentMethod != null) {
+                val didTokenizeEvent = DidTokenizePaymentMethod(
+                    paymentMethod = paymentMethod.original,
+                    customerTokenId = customerTokenId
+                )
+                dispatch(didTokenizeEvent)
+            }
+        }
         when (state.processingPaymentMethod) {
             is Card -> latestCardProcessingRequest?.let { request ->
                 interactorScope.launch {

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -39,6 +39,7 @@ import com.processout.sdk.core.onSuccess
 import com.processout.sdk.ui.base.BaseInteractor
 import com.processout.sdk.ui.card.tokenization.*
 import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration.BillingAddressConfiguration.CollectionMode
+import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration.SavingConfiguration
 import com.processout.sdk.ui.card.tokenization.delegate.*
 import com.processout.sdk.ui.card.tokenization.delegate.POCardTokenizationEligibility.Eligible
 import com.processout.sdk.ui.card.tokenization.delegate.POCardTokenizationEligibility.NotEligible
@@ -502,7 +503,11 @@ internal class DynamicCheckoutInteractor(
                 mode = configuration.billingAddress.collectionMode.map(),
                 countryCodes = configuration.billingAddress.restrictToCountryCodes
             ),
-            savingAllowed = configuration.savingAllowed
+            saving = if (configuration.savingAllowed)
+                SavingConfiguration(
+                    enabledByDefault = saving?.enabledByDefault ?: false,
+                    required = saving?.required ?: false
+                ) else null
         )
 
     private fun POBillingAddressCollectionMode.map(): CollectionMode =

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractorState.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractorState.kt
@@ -65,7 +65,8 @@ internal data class DynamicCheckoutInteractorState(
 
     data class Field(
         val id: String,
-        val value: TextFieldValue = TextFieldValue()
+        val value: TextFieldValue = TextFieldValue(),
+        val enabled: Boolean = true
     )
 
     data class Actions(

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutScreen.kt
@@ -579,13 +579,15 @@ private fun CheckboxField(
         text = state.label ?: String(),
         checked = state.value.text.toBooleanStrictOrNull() ?: false,
         onCheckedChange = {
-            onEvent(
-                FieldValueChanged(
-                    paymentMethodId = id,
-                    fieldId = state.id,
-                    value = FieldValue.Text(value = TextFieldValue(text = it.toString()))
+            if (state.enabled) {
+                onEvent(
+                    FieldValueChanged(
+                        paymentMethodId = id,
+                        fieldId = state.id,
+                        value = FieldValue.Text(value = TextFieldValue(text = it.toString()))
+                    )
                 )
-            )
+            }
         },
         modifier = modifier,
         style = style,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutScreen.kt
@@ -183,9 +183,9 @@ private fun Content(
                 isLightTheme = isLightTheme
             )
         }
-        if (state.regularPayments.elements.isNotEmpty()) {
-            RegularPayments(
-                payments = state.regularPayments,
+        state.regularCheckout?.let {
+            RegularCheckout(
+                state = it,
                 onEvent = onEvent,
                 style = style,
                 isLightTheme = isLightTheme
@@ -195,29 +195,7 @@ private fun Content(
 }
 
 @Composable
-private fun ExpressCheckout(
-    state: ExpressCheckout,
-    onEvent: (DynamicCheckoutEvent) -> Unit,
-    style: DynamicCheckoutScreen.Style,
-    isLightTheme: Boolean
-) {
-    if (state.header != null) {
-        ExpressCheckoutHeader(
-            state = state.header,
-            onEvent = onEvent,
-            style = style.sectionHeader
-        )
-    }
-    ExpressPayments(
-        payments = state.expressPayments,
-        onEvent = onEvent,
-        style = style,
-        isLightTheme = isLightTheme
-    )
-}
-
-@Composable
-private fun ExpressCheckoutHeader(
+private fun SectionHeader(
     state: SectionHeader,
     onEvent: (DynamicCheckoutEvent) -> Unit,
     style: SectionHeaderStyle,
@@ -259,6 +237,28 @@ private fun ExpressCheckoutHeader(
             )
         }
     }
+}
+
+@Composable
+private fun ExpressCheckout(
+    state: ExpressCheckout,
+    onEvent: (DynamicCheckoutEvent) -> Unit,
+    style: DynamicCheckoutScreen.Style,
+    isLightTheme: Boolean
+) {
+    state.header?.let {
+        SectionHeader(
+            state = it,
+            onEvent = onEvent,
+            style = style.sectionHeader
+        )
+    }
+    ExpressPayments(
+        payments = state.expressPayments,
+        onEvent = onEvent,
+        style = style,
+        isLightTheme = isLightTheme
+    )
 }
 
 @Composable
@@ -356,6 +356,28 @@ private fun ExpressPayment(
             }
         )
     }
+}
+
+@Composable
+private fun RegularCheckout(
+    state: RegularCheckout,
+    onEvent: (DynamicCheckoutEvent) -> Unit,
+    style: DynamicCheckoutScreen.Style,
+    isLightTheme: Boolean
+) {
+    state.header?.let {
+        SectionHeader(
+            state = it,
+            onEvent = onEvent,
+            style = style.sectionHeader
+        )
+    }
+    RegularPayments(
+        payments = state.regularPayments,
+        onEvent = onEvent,
+        style = style,
+        isLightTheme = isLightTheme
+    )
 }
 
 @Composable

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutScreen.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutScreen.kt
@@ -201,11 +201,13 @@ private fun ExpressCheckout(
     style: DynamicCheckoutScreen.Style,
     isLightTheme: Boolean
 ) {
-    ExpressCheckoutHeader(
-        state = state.header,
-        onEvent = onEvent,
-        style = style.sectionHeader
-    )
+    if (state.header != null) {
+        ExpressCheckoutHeader(
+            state = state.header,
+            onEvent = onEvent,
+            style = style.sectionHeader
+        )
+    }
     ExpressPayments(
         payments = state.expressPayments,
         onEvent = onEvent,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
@@ -104,7 +104,7 @@ internal class DynamicCheckoutViewModel private constructor(
         } else {
             Loaded(
                 expressCheckout = expressCheckout(interactorState),
-                regularPayments = regularPayments(interactorState, cardTokenizationState, nativeAlternativePaymentState),
+                regularCheckout = regularCheckout(interactorState, cardTokenizationState, nativeAlternativePaymentState),
                 cancelAction = cancelAction,
                 errorMessage = interactorState.errorMessage
             )
@@ -299,11 +299,40 @@ internal class DynamicCheckoutViewModel private constructor(
         )
     }
 
+    private fun regularCheckout(
+        interactorState: DynamicCheckoutInteractorState,
+        cardTokenizationState: CardTokenizationViewModelState,
+        nativeAlternativePaymentState: NativeAlternativePaymentViewModelState
+    ): RegularCheckout? {
+        val configuration = configuration.regularCheckout ?: return null
+        val regularPayments = regularPayments(interactorState, cardTokenizationState, nativeAlternativePaymentState)
+        if (regularPayments.isEmpty()) {
+            return null
+        }
+        return RegularCheckout(
+            header = regularCheckoutSectionHeader(configuration),
+            regularPayments = POImmutableList(regularPayments)
+        )
+    }
+
+    private fun regularCheckoutSectionHeader(
+        configuration: PODynamicCheckoutConfiguration.RegularCheckout
+    ): SectionHeader? {
+        if (configuration.title?.isBlank() == true) {
+            return null
+        }
+        return SectionHeader(
+            title = configuration.title
+                ?: app.getString(R.string.po_dynamic_checkout_regular_checkout),
+            action = null
+        )
+    }
+
     private fun regularPayments(
         interactorState: DynamicCheckoutInteractorState,
         cardTokenizationState: CardTokenizationViewModelState,
         nativeAlternativePaymentState: NativeAlternativePaymentViewModelState
-    ): POImmutableList<RegularPayment> =
+    ): List<RegularPayment> =
         interactorState.paymentMethods.mapNotNull { paymentMethod ->
             val id = paymentMethod.id
             val selected = id == interactorState.selectedPaymentMethod?.id
@@ -357,7 +386,7 @@ internal class DynamicCheckoutViewModel private constructor(
                 )
                 else -> null
             }
-        }.let { POImmutableList(it) }
+        }
 
     private fun regularPaymentState(
         display: Display,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
@@ -379,7 +379,8 @@ internal class DynamicCheckoutViewModel private constructor(
             FieldState(
                 id = id,
                 value = value,
-                label = title
+                label = title,
+                enabled = enabled
             )
         )
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
@@ -195,12 +195,23 @@ internal class DynamicCheckoutViewModel private constructor(
             return null
         }
         return ExpressCheckout(
-            header = SectionHeader(
-                title = configuration.title
-                    ?: app.getString(R.string.po_dynamic_checkout_express_checkout),
-                action = savedPaymentMethodsAction(interactorState, configuration)
-            ),
+            header = expressCheckoutSectionHeader(interactorState, configuration),
             expressPayments = POImmutableList(expressPayments)
+        )
+    }
+
+    private fun expressCheckoutSectionHeader(
+        interactorState: DynamicCheckoutInteractorState,
+        configuration: PODynamicCheckoutConfiguration.ExpressCheckout
+    ): SectionHeader? {
+        val savedPaymentMethodsAction = savedPaymentMethodsAction(interactorState, configuration)
+        if (configuration.title?.isBlank() == true && savedPaymentMethodsAction == null) {
+            return null
+        }
+        return SectionHeader(
+            title = configuration.title
+                ?: app.getString(R.string.po_dynamic_checkout_express_checkout),
+            action = savedPaymentMethodsAction
         )
     }
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModel.kt
@@ -189,34 +189,38 @@ internal class DynamicCheckoutViewModel private constructor(
     private fun expressCheckout(
         interactorState: DynamicCheckoutInteractorState
     ): ExpressCheckout? {
+        val configuration = configuration.expressCheckout ?: return null
         val expressPayments = expressPayments(interactorState)
         if (expressPayments.isEmpty()) {
             return null
         }
         return ExpressCheckout(
             header = SectionHeader(
-                title = configuration.expressCheckout.title
+                title = configuration.title
                     ?: app.getString(R.string.po_dynamic_checkout_express_checkout),
-                action = savedPaymentMethodsAction(interactorState)
+                action = savedPaymentMethodsAction(interactorState, configuration)
             ),
             expressPayments = POImmutableList(expressPayments)
         )
     }
 
     private fun savedPaymentMethodsAction(
-        interactorState: DynamicCheckoutInteractorState
-    ): POActionState? = with(configuration.expressCheckout) {
-        if (interactorState.paymentMethods.deletingAllowed)
-            POActionState(
-                id = interactorState.actions.savedPaymentMethodsId,
-                text = settingsButton?.text ?: String(),
-                primary = false,
-                icon = settingsButton?.icon
-                    ?: PODrawableImage(
-                        resId = com.processout.sdk.ui.R.drawable.po_icon_settings,
-                        renderingMode = POImageRenderingMode.ORIGINAL
-                    )
-            ) else null
+        interactorState: DynamicCheckoutInteractorState,
+        configuration: PODynamicCheckoutConfiguration.ExpressCheckout
+    ): POActionState? {
+        if (!interactorState.paymentMethods.deletingAllowed) {
+            return null
+        }
+        return POActionState(
+            id = interactorState.actions.savedPaymentMethodsId,
+            text = configuration.settingsButton?.text ?: String(),
+            primary = false,
+            icon = configuration.settingsButton?.icon
+                ?: PODrawableImage(
+                    resId = com.processout.sdk.ui.R.drawable.po_icon_settings,
+                    renderingMode = POImageRenderingMode.ORIGINAL
+                )
+        )
     }
 
     private val List<PaymentMethod>.deletingAllowed: Boolean

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModelState.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModelState.kt
@@ -42,7 +42,7 @@ internal sealed interface DynamicCheckoutViewModelState {
 
     @Immutable
     data class ExpressCheckout(
-        val header: SectionHeader,
+        val header: SectionHeader?,
         val expressPayments: POImmutableList<ExpressPayment>
     )
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModelState.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutViewModelState.kt
@@ -22,7 +22,7 @@ internal sealed interface DynamicCheckoutViewModelState {
     @Immutable
     data class Loaded(
         val expressCheckout: ExpressCheckout?,
-        val regularPayments: POImmutableList<RegularPayment>,
+        val regularCheckout: RegularCheckout?,
         val cancelAction: POActionState?,
         val errorMessage: String? = null
     ) : DynamicCheckoutViewModelState
@@ -44,6 +44,12 @@ internal sealed interface DynamicCheckoutViewModelState {
     data class ExpressCheckout(
         val header: SectionHeader?,
         val expressPayments: POImmutableList<ExpressPayment>
+    )
+
+    @Immutable
+    data class RegularCheckout(
+        val header: SectionHeader?,
+        val regularPayments: POImmutableList<RegularPayment>
     )
 
     @Immutable

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutActivity.kt
@@ -114,7 +114,12 @@ class PODynamicCheckoutActivity : POBaseTransparentPortraitActivity() {
                 defaultAddress = billingAddress.defaultAddress,
                 attachDefaultsToPaymentMethod = billingAddress.attachDefaultsToPaymentMethod
             ),
-            saving = null,
+            saving = configuration.saving?.let {
+                POCardTokenizationConfiguration.SavingConfiguration(
+                    enabledByDefault = it.enabledByDefault,
+                    required = it.required
+                )
+            },
             submitButton = configuration.submitButton.let {
                 POCardTokenizationConfiguration.Button(
                     text = it.text,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutActivity.kt
@@ -114,6 +114,7 @@ class PODynamicCheckoutActivity : POBaseTransparentPortraitActivity() {
                 defaultAddress = billingAddress.defaultAddress,
                 attachDefaultsToPaymentMethod = billingAddress.attachDefaultsToPaymentMethod
             ),
+            saving = null,
             submitButton = configuration.submitButton.let {
                 POCardTokenizationConfiguration.Button(
                     text = it.text,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
@@ -29,6 +29,7 @@ import kotlinx.parcelize.Parcelize
  * @param[card] Card payment configuration.
  * @param[googlePay] Google Pay configuration.
  * @param[alternativePayment] Alternative payment configuration.
+ * @param[saving] Saving configuration for supported payment methods.
  * @param[submitButton] Submit button configuration.
  * @param[cancelButton] Cancel button configuration.
  * @param[cancelOnBackPressed] Specifies whether the screen should be cancelled on back button press or back gesture.
@@ -47,6 +48,7 @@ data class PODynamicCheckoutConfiguration(
     val card: CardConfiguration = CardConfiguration(),
     val googlePay: GooglePayConfiguration = GooglePayConfiguration(),
     val alternativePayment: AlternativePaymentConfiguration = AlternativePaymentConfiguration(),
+    val saving: SavingConfiguration? = SavingConfiguration(),
     val submitButton: Button = Button(),
     val cancelButton: CancelButton? = CancelButton(),
     val cancelOnBackPressed: Boolean = true,
@@ -284,6 +286,18 @@ data class PODynamicCheckoutConfiguration(
             val confirmation: POActionConfirmationConfiguration? = null
         ) : Parcelable
     }
+
+    /**
+     * Payment method saving configuration.
+     *
+     * @param[enabledByDefault] Initial selection state.
+     * @param[required] If `true`, saving is enforced and cannot be disabled by the user.
+     */
+    @Parcelize
+    data class SavingConfiguration(
+        val enabledByDefault: Boolean = false,
+        val required: Boolean = false
+    ) : Parcelable
 
     /**
      * Button configuration.

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
@@ -23,6 +23,9 @@ import kotlinx.parcelize.Parcelize
  *
  * @param[invoiceRequest] Request to fetch invoice for payment.
  * @param[expressCheckout] Express checkout section configuration.
+ * Controls the visibility and appearance of the saved payment methods.
+ * Set this value to `null` to hide the entire "Express Checkout" section and omit saved payments from the flow.
+ * This setting does not affect the availability of other payment options, nor does it affect whether the user can save a payment method.
  * @param[card] Card payment configuration.
  * @param[googlePay] Google Pay configuration.
  * @param[alternativePayment] Alternative payment configuration.
@@ -40,7 +43,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class PODynamicCheckoutConfiguration(
     val invoiceRequest: POInvoiceRequest,
-    val expressCheckout: ExpressCheckout = ExpressCheckout(),
+    val expressCheckout: ExpressCheckout? = ExpressCheckout(),
     val card: CardConfiguration = CardConfiguration(),
     val googlePay: GooglePayConfiguration = GooglePayConfiguration(),
     val alternativePayment: AlternativePaymentConfiguration = AlternativePaymentConfiguration(),

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
@@ -65,7 +65,7 @@ data class PODynamicCheckoutConfiguration(
     /**
      * Specifies express checkout section configuration.
      *
-     * @param[title] Custom section title.
+     * @param[title] Custom section title. Set `null` to use the default value, or an empty string to remove the title.
      * @param[settingsButton] Settings button configuration.
      */
     @Parcelize

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
@@ -26,6 +26,10 @@ import kotlinx.parcelize.Parcelize
  * Controls the visibility and appearance of the saved payment methods.
  * Set this value to `null` to hide the entire "Express Checkout" section and omit saved payments from the flow.
  * This setting does not affect the availability of other payment options, nor does it affect whether the user can save a payment method.
+ * @param[regularCheckout] Regular checkout section configuration.
+ * Controls the visibility and appearance of the regular payment methods section.
+ * Set this value to `null` to hide the entire "Regular Checkout" section.
+ * This setting does not affect the availability of saved payment options.
  * @param[card] Card payment configuration.
  * @param[googlePay] Google Pay configuration.
  * @param[alternativePayment] Alternative payment configuration.
@@ -45,6 +49,7 @@ import kotlinx.parcelize.Parcelize
 data class PODynamicCheckoutConfiguration(
     val invoiceRequest: POInvoiceRequest,
     val expressCheckout: ExpressCheckout? = ExpressCheckout(),
+    val regularCheckout: RegularCheckout? = RegularCheckout(),
     val card: CardConfiguration = CardConfiguration(),
     val googlePay: GooglePayConfiguration = GooglePayConfiguration(),
     val alternativePayment: AlternativePaymentConfiguration = AlternativePaymentConfiguration(),
@@ -67,6 +72,16 @@ data class PODynamicCheckoutConfiguration(
     data class ExpressCheckout(
         val title: String? = null,
         val settingsButton: Button? = null
+    ) : Parcelable
+
+    /**
+     * Specifies regular checkout section configuration.
+     *
+     * @param[title] Custom section title. Set `null` to use the default value, or an empty string to remove the title.
+     */
+    @Parcelize
+    data class RegularCheckout(
+        val title: String? = String()
     ) : Parcelable
 
     /**

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutLauncher.kt
@@ -17,8 +17,6 @@ import com.processout.sdk.core.POUnit
 import com.processout.sdk.core.ProcessOutActivityResult
 import com.processout.sdk.ui.card.tokenization.delegate.CardTokenizationEligibilityRequest
 import com.processout.sdk.ui.card.tokenization.delegate.CardTokenizationPreferredSchemeRequest
-import com.processout.sdk.ui.card.tokenization.delegate.POCardTokenizationEligibility.Eligible
-import com.processout.sdk.ui.card.tokenization.delegate.toResponse
 import com.processout.sdk.ui.checkout.delegate.*
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 import com.processout.sdk.ui.napm.delegate.v2.PONativeAlternativePaymentEvent
@@ -148,7 +146,11 @@ class PODynamicCheckoutLauncher private constructor(
             coroutineScope = scope
         ) { request ->
             scope.launch {
-                eventDispatcher.send(request.toResponse(eligibility = Eligible()))
+                val eligibility = delegate.evaluateEligibility(
+                    iin = request.iin,
+                    issuerInformation = request.issuerInformation
+                )
+                eventDispatcher.send(request.toDynamicCheckoutResponse(eligibility))
             }
         }
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutLauncher.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutLauncher.kt
@@ -159,7 +159,7 @@ class PODynamicCheckoutLauncher private constructor(
         ) { request ->
             scope.launch {
                 val preferredScheme = delegate.preferredScheme(request.issuerInformation)
-                eventDispatcher.send(request.toResponse(preferredScheme))
+                eventDispatcher.send(request.toDynamicCheckoutResponse(preferredScheme))
             }
         }
     }

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/delegate/DynamicCheckoutCardEligibility.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/delegate/DynamicCheckoutCardEligibility.kt
@@ -1,0 +1,18 @@
+package com.processout.sdk.ui.checkout.delegate
+
+import com.processout.sdk.api.dispatcher.POEventDispatcher
+import com.processout.sdk.api.model.response.POCardIssuerInformation
+import com.processout.sdk.ui.card.tokenization.delegate.CardTokenizationEligibilityRequest
+import com.processout.sdk.ui.card.tokenization.delegate.POCardTokenizationEligibility
+import java.util.UUID
+
+internal data class DynamicCheckoutCardEligibilityResponse(
+    override val uuid: UUID,
+    val iin: String,
+    val issuerInformation: POCardIssuerInformation,
+    val eligibility: POCardTokenizationEligibility?
+) : POEventDispatcher.Response
+
+internal fun CardTokenizationEligibilityRequest.toDynamicCheckoutResponse(
+    eligibility: POCardTokenizationEligibility?
+) = DynamicCheckoutCardEligibilityResponse(uuid, iin, issuerInformation, eligibility)

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/delegate/DynamicCheckoutCardPreferredScheme.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/delegate/DynamicCheckoutCardPreferredScheme.kt
@@ -1,0 +1,16 @@
+package com.processout.sdk.ui.checkout.delegate
+
+import com.processout.sdk.api.dispatcher.POEventDispatcher
+import com.processout.sdk.api.model.response.POCardIssuerInformation
+import com.processout.sdk.ui.card.tokenization.delegate.CardTokenizationPreferredSchemeRequest
+import java.util.UUID
+
+internal data class DynamicCheckoutCardPreferredSchemeResponse(
+    override val uuid: UUID,
+    val issuerInformation: POCardIssuerInformation,
+    val preferredScheme: String?
+) : POEventDispatcher.Response
+
+internal fun CardTokenizationPreferredSchemeRequest.toDynamicCheckoutResponse(
+    preferredScheme: String?
+) = DynamicCheckoutCardPreferredSchemeResponse(uuid, issuerInformation, preferredScheme)

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/delegate/PODynamicCheckoutDelegate.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/delegate/PODynamicCheckoutDelegate.kt
@@ -7,6 +7,7 @@ import com.processout.sdk.api.model.response.POCardIssuerInformation
 import com.processout.sdk.api.model.response.PODynamicCheckoutPaymentMethod
 import com.processout.sdk.api.model.response.POInvoice
 import com.processout.sdk.api.model.response.napm.v2.PONativeAlternativePaymentElement
+import com.processout.sdk.ui.card.tokenization.delegate.POCardTokenizationEligibility
 import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 import com.processout.sdk.ui.napm.delegate.v2.PONativeAlternativePaymentEvent
@@ -60,6 +61,17 @@ interface PODynamicCheckoutDelegate {
         paymentMethod: PODynamicCheckoutPaymentMethod,
         request: POInvoiceAuthorizationRequest
     ): POInvoiceAuthorizationRequest = request
+
+    /**
+     * Allows to evaluate card eligibility for tokenization based on issuer information.
+     *
+     * @param[iin] Issuer identification number.
+     * @param[issuerInformation] Resolved issuer information.
+     */
+    suspend fun evaluateEligibility(
+        iin: String,
+        issuerInformation: POCardIssuerInformation
+    ): POCardTokenizationEligibility? = null
 
     /**
      * Allows to choose default preferred card scheme based on issuer information.

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/delegate/PODynamicCheckoutDelegate.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/delegate/PODynamicCheckoutDelegate.kt
@@ -67,7 +67,7 @@ interface PODynamicCheckoutDelegate {
      */
     fun preferredScheme(
         issuerInformation: POCardIssuerInformation
-    ): String? = issuerInformation.scheme
+    ): String? = null
 
     /**
      * Allows to prefill default values for the given [parameters] during native alternative payment.

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/delegate/PODynamicCheckoutEvent.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/delegate/PODynamicCheckoutEvent.kt
@@ -44,6 +44,14 @@ sealed class PODynamicCheckoutEvent {
     ) : PODynamicCheckoutEvent()
 
     /**
+     * Event is sent after the payment method is tokenized.
+     */
+    data class DidTokenizePaymentMethod(
+        val paymentMethod: PODynamicCheckoutPaymentMethod,
+        val customerTokenId: String
+    ) : PODynamicCheckoutEvent()
+
+    /**
      * Event is sent after payment was confirmed to be captured. This is a final event.
      */
     data object DidCompletePayment : PODynamicCheckoutEvent()

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/NativeAlternativePaymentInteractor.kt
@@ -742,6 +742,7 @@ internal class NativeAlternativePaymentInteractor(
         stateValue: NextStepStateValue,
         redirect: PONativeAlternativePaymentRedirect
     ) {
+        dispatch(WillStartRedirect(redirect))
         when (redirect.type) {
             RedirectType.WEB -> webRedirect(
                 stateValue = stateValue,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/napm/delegate/v2/PONativeAlternativePaymentEvent.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/napm/delegate/v2/PONativeAlternativePaymentEvent.kt
@@ -1,6 +1,7 @@
 package com.processout.sdk.ui.napm.delegate.v2
 
 import com.processout.sdk.api.model.response.napm.v2.PONativeAlternativePaymentElement
+import com.processout.sdk.api.model.response.napm.v2.PONativeAlternativePaymentRedirect
 import com.processout.sdk.api.model.response.napm.v2.PONativeAlternativePaymentState
 import com.processout.sdk.core.ProcessOutResult
 import com.processout.sdk.core.annotation.ProcessOutInternalApi
@@ -53,9 +54,20 @@ sealed class PONativeAlternativePaymentEvent {
 
     /**
      * Event is sent when parameters submission failed and the error is retriable, otherwise expect [DidFail] event.
+     *
+     * @param[failure] Failure details.
      */
     data class DidFailToSubmitParameters(
         val failure: ProcessOutResult.Failure
+    ) : PONativeAlternativePaymentEvent()
+
+    /**
+     * Event is sent just before redirecting to a web or a deep/app link.
+     *
+     * @param[redirect] Redirect details.
+     */
+    data class WillStartRedirect(
+        val redirect: PONativeAlternativePaymentRedirect
     ) : PONativeAlternativePaymentEvent()
 
     /**
@@ -82,6 +94,7 @@ sealed class PONativeAlternativePaymentEvent {
     /**
      * Event is sent when unretryable error occurs. This is a final event.
      *
+     * @param[failure] Failure details.
      * @param[paymentState] The payment state provides additional context about where in the payment process the failure occurred.
      * For example, in the event of a user-initiated cancellation,
      * this state can be used to determine which step the user was on when they canceled.


### PR DESCRIPTION
* Fixed invoice invalidation with nAPMs
* Emit events: `WillStartRedirect` & `DidTokenizePaymentMethod`
* Support card scheme selection default order
* Support card eligibility restrictions
* Added `authorizeV2` method that returns `POInvoiceAuthorizationResponse`
* Allow to hide express and regular checkout sections via configuration
* Remove express checkout header if there is no content
* Added customizable title for regular checkout section
* Added `SavingConfiguration` for cards and DC payment methods
* Added `POInvoiceAuthorizationOutcome`