### PR TITLE
fix(ad-hoc): POCustomTabRedirectActivity crash when it started after app process death

### DIFF
--- a/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabRedirectActivity.kt
+++ b/sdk/src/main/kotlin/com/processout/sdk/ui/web/customtab/POCustomTabRedirectActivity.kt
@@ -13,7 +13,9 @@ class POCustomTabRedirectActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         intent.data?.let { uri ->
-            ProcessOut.instance.processDeepLink(hostActivity = this, uri)
+            if (ProcessOut.isConfigured) {
+                ProcessOut.instance.processDeepLink(hostActivity = this, uri)
+            }
         }
         finish()
     }


### PR DESCRIPTION
**Issue:**
`POCustomTabRedirectActivity` is exported and can be started by Android system externally to handle deep/app link. There is a case when this happens after the process death and `ProcessOut.instance` is not configured yet in the new process, so accessing it causes a crash.
**Fix:**
Check if `ProcessOut.isConfigured` before calling `ProcessOut.instance.processDeepLink(...)` to prevent the crash.