### PR TITLE
feat(ad-hoc): Support card field labels customization

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -5,4 +5,5 @@
 /runConfigurations.xml
 /deviceManager.xml
 /swift-toolchain.xml
+/noctule.xml
 /other.xml

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationInteractor.kt
@@ -169,11 +169,11 @@ internal class CardTokenizationInteractor(
         Field(id = CardFieldId.EXPIRATION),
         Field(
             id = CardFieldId.CVC,
-            shouldCollect = configuration.cvcRequired
+            shouldCollect = configuration.cvc != null
         ),
         Field(
             id = CardFieldId.CARDHOLDER,
-            shouldCollect = configuration.cardholderNameRequired
+            shouldCollect = configuration.cardholderName != null
         )
     )
 

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
@@ -366,7 +366,7 @@ internal class CardTokenizationViewModel private constructor(
         val items = listOf(
             checkboxField(
                 field = saveCardField,
-                title = app.getString(R.string.po_card_tokenization_save_card)
+                text = app.getString(R.string.po_card_tokenization_save_card)
             )
         )
         return Section(
@@ -473,12 +473,12 @@ internal class CardTokenizationViewModel private constructor(
 
     private fun checkboxField(
         field: Field,
-        title: String? = null
+        text: String? = null
     ): Item = Item.CheckboxField(
         FieldState(
             id = field.id,
             value = field.value,
-            label = title,
+            label = text,
             enabled = field.enabled,
             isError = !field.isValid
         )

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
@@ -175,7 +175,7 @@ internal class CardTokenizationViewModel private constructor(
             when (field.id) {
                 CardFieldId.NUMBER -> cardNumberField = field(
                     field = field,
-                    placeholder = app.getString(R.string.po_card_tokenization_card_details_number_placeholder),
+                    label = app.getString(R.string.po_card_tokenization_card_details_number_placeholder),
                     contentDescription = app.getString(R.string.po_card_tokenization_content_description_card_number),
                     iconResId = cardSchemeDrawableResId(scheme = state.preferredSchemeField.value.text),
                     forceTextDirectionLtr = true,
@@ -190,7 +190,7 @@ internal class CardTokenizationViewModel private constructor(
                 CardFieldId.EXPIRATION -> trackFields.add(
                     field(
                         field = field,
-                        placeholder = app.getString(R.string.po_card_tokenization_card_details_expiration_placeholder),
+                        label = app.getString(R.string.po_card_tokenization_card_details_expiration_placeholder),
                         contentDescription = app.getString(R.string.po_card_tokenization_content_description_card_expiration),
                         forceTextDirectionLtr = true,
                         inputFilter = CardExpirationInputFilter(),
@@ -207,7 +207,7 @@ internal class CardTokenizationViewModel private constructor(
                     trackFields.add(
                         field(
                             field = field.copy(value = inputFilter.filter(field.value)),
-                            placeholder = app.getString(R.string.po_card_tokenization_card_details_cvc_placeholder),
+                            label = app.getString(R.string.po_card_tokenization_card_details_cvc_placeholder),
                             forceTextDirectionLtr = true,
                             iconResId = com.processout.sdk.ui.R.drawable.po_card_back,
                             inputFilter = inputFilter,
@@ -221,7 +221,7 @@ internal class CardTokenizationViewModel private constructor(
                 }
                 CardFieldId.CARDHOLDER -> cardholderField = field(
                     field = field,
-                    placeholder = app.getString(R.string.po_card_tokenization_card_details_cardholder_placeholder),
+                    label = app.getString(R.string.po_card_tokenization_card_details_cardholder_placeholder),
                     keyboardOptions = KeyboardOptions(
                         capitalization = KeyboardCapitalization.Words,
                         autoCorrectEnabled = false,
@@ -262,7 +262,7 @@ internal class CardTokenizationViewModel private constructor(
                 )?.also { items.add(it) }
                 AddressFieldId.ADDRESS_1 -> field(
                     field = field,
-                    placeholder = app.getString(R.string.po_card_tokenization_billing_address_street, 1),
+                    label = app.getString(R.string.po_card_tokenization_billing_address_street, 1),
                     keyboardOptions = KeyboardOptions(
                         capitalization = KeyboardCapitalization.Sentences,
                         keyboardType = KeyboardType.Text,
@@ -272,7 +272,7 @@ internal class CardTokenizationViewModel private constructor(
                 )?.also { items.add(it) }
                 AddressFieldId.ADDRESS_2 -> field(
                     field = field,
-                    placeholder = app.getString(R.string.po_card_tokenization_billing_address_street, 2),
+                    label = app.getString(R.string.po_card_tokenization_billing_address_street, 2),
                     keyboardOptions = KeyboardOptions(
                         capitalization = KeyboardCapitalization.Sentences,
                         keyboardType = KeyboardType.Text,
@@ -282,7 +282,7 @@ internal class CardTokenizationViewModel private constructor(
                 )?.also { items.add(it) }
                 AddressFieldId.CITY -> field(
                     field = field,
-                    placeholder = specification?.cityUnit?.let { app.getString(it.stringResId()) },
+                    label = specification?.cityUnit?.let { app.getString(it.stringResId()) },
                     keyboardOptions = KeyboardOptions(
                         capitalization = KeyboardCapitalization.Sentences,
                         keyboardType = KeyboardType.Text,
@@ -292,7 +292,7 @@ internal class CardTokenizationViewModel private constructor(
                 )?.also { items.add(it) }
                 AddressFieldId.STATE -> field(
                     field = field,
-                    placeholder = specification?.stateUnit?.let { app.getString(it.stringResId()) },
+                    label = specification?.stateUnit?.let { app.getString(it.stringResId()) },
                     keyboardOptions = KeyboardOptions(
                         capitalization = KeyboardCapitalization.Sentences,
                         keyboardType = KeyboardType.Text,
@@ -302,7 +302,7 @@ internal class CardTokenizationViewModel private constructor(
                 )?.also { items.add(it) }
                 AddressFieldId.POSTAL_CODE -> field(
                     field = field,
-                    placeholder = specification?.postcodeUnit?.let { app.getString(it.stringResId()) },
+                    label = specification?.postcodeUnit?.let { app.getString(it.stringResId()) },
                     forceTextDirectionLtr = true,
                     keyboardOptions = KeyboardOptions(
                         capitalization = KeyboardCapitalization.Characters,
@@ -390,7 +390,7 @@ internal class CardTokenizationViewModel private constructor(
 
     private fun field(
         field: Field,
-        placeholder: String? = null,
+        label: String? = null,
         contentDescription: String? = null,
         @DrawableRes iconResId: Int? = null,
         forceTextDirectionLtr: Boolean = false,
@@ -410,7 +410,7 @@ internal class CardTokenizationViewModel private constructor(
         }
         return textField(
             field = field,
-            placeholder = placeholder,
+            label = label,
             contentDescription = contentDescription,
             iconResId = iconResId,
             forceTextDirectionLtr = forceTextDirectionLtr,
@@ -423,7 +423,7 @@ internal class CardTokenizationViewModel private constructor(
 
     private fun textField(
         field: Field,
-        placeholder: String? = null,
+        label: String? = null,
         contentDescription: String? = null,
         @DrawableRes iconResId: Int? = null,
         forceTextDirectionLtr: Boolean = false,
@@ -435,7 +435,7 @@ internal class CardTokenizationViewModel private constructor(
         FieldState(
             id = field.id,
             value = field.value,
-            label = placeholder,
+            label = label,
             contentDescription = contentDescription,
             iconResId = iconResId,
             enabled = field.enabled,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/CardTokenizationViewModel.kt
@@ -175,8 +175,10 @@ internal class CardTokenizationViewModel private constructor(
             when (field.id) {
                 CardFieldId.NUMBER -> cardNumberField = field(
                     field = field,
-                    label = app.getString(R.string.po_card_tokenization_card_details_number_placeholder),
-                    contentDescription = app.getString(R.string.po_card_tokenization_content_description_card_number),
+                    label = configuration.cardNumber.label
+                        ?: app.getString(R.string.po_card_tokenization_card_details_number_placeholder),
+                    contentDescription = configuration.cardNumber.contentDescription
+                        ?: app.getString(R.string.po_card_tokenization_content_description_card_number),
                     iconResId = cardSchemeDrawableResId(scheme = state.preferredSchemeField.value.text),
                     forceTextDirectionLtr = true,
                     inputFilter = CardNumberInputFilter(),
@@ -190,8 +192,10 @@ internal class CardTokenizationViewModel private constructor(
                 CardFieldId.EXPIRATION -> trackFields.add(
                     field(
                         field = field,
-                        label = app.getString(R.string.po_card_tokenization_card_details_expiration_placeholder),
-                        contentDescription = app.getString(R.string.po_card_tokenization_content_description_card_expiration),
+                        label = configuration.expirationDate.label
+                            ?: app.getString(R.string.po_card_tokenization_card_details_expiration_placeholder),
+                        contentDescription = configuration.expirationDate.contentDescription
+                            ?: app.getString(R.string.po_card_tokenization_content_description_card_expiration),
                         forceTextDirectionLtr = true,
                         inputFilter = CardExpirationInputFilter(),
                         visualTransformation = CardExpirationVisualTransformation(),
@@ -207,7 +211,9 @@ internal class CardTokenizationViewModel private constructor(
                     trackFields.add(
                         field(
                             field = field.copy(value = inputFilter.filter(field.value)),
-                            label = app.getString(R.string.po_card_tokenization_card_details_cvc_placeholder),
+                            label = configuration.cvc?.label
+                                ?: app.getString(R.string.po_card_tokenization_card_details_cvc_placeholder),
+                            contentDescription = configuration.cvc?.contentDescription,
                             forceTextDirectionLtr = true,
                             iconResId = com.processout.sdk.ui.R.drawable.po_card_back,
                             inputFilter = inputFilter,
@@ -221,7 +227,9 @@ internal class CardTokenizationViewModel private constructor(
                 }
                 CardFieldId.CARDHOLDER -> cardholderField = field(
                     field = field,
-                    label = app.getString(R.string.po_card_tokenization_card_details_cardholder_placeholder),
+                    label = configuration.cardholderName?.label
+                        ?: app.getString(R.string.po_card_tokenization_card_details_cardholder_placeholder),
+                    contentDescription = configuration.cardholderName?.contentDescription,
                     keyboardOptions = KeyboardOptions(
                         capitalization = KeyboardCapitalization.Words,
                         autoCorrectEnabled = false,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
@@ -145,6 +145,18 @@ data class POCardTokenizationConfiguration(
     )
 
     /**
+     * Text field configuration.
+     *
+     * @param[label] Text field label. Pass _null_ to use the default label.
+     * @param[contentDescription] Content description for accessibility. Pass _null_ to use the default text.
+     */
+    @Parcelize
+    data class TextField(
+        val label: String? = null,
+        val contentDescription: String? = null
+    ) : Parcelable
+
+    /**
      * Defines card scanner configuration.
      *
      * @param[scanButton] Scan button configuration.
@@ -216,7 +228,7 @@ data class POCardTokenizationConfiguration(
     /**
      * Button configuration.
      *
-     * @param[text] Button text. Pass _null_ to use default text.
+     * @param[text] Button text. Pass _null_ to use the default text.
      * @param[icon] Button icon drawable resource. Pass _null_ to hide.
      */
     @Parcelize
@@ -228,7 +240,7 @@ data class POCardTokenizationConfiguration(
     /**
      * Cancel button configuration.
      *
-     * @param[text] Button text. Pass _null_ to use default text.
+     * @param[text] Button text. Pass _null_ to use the default text.
      * @param[icon] Button icon drawable resource. Pass _null_ to hide.
      * @param[confirmation] Specifies action confirmation configuration (e.g. dialog).
      * Use _null_ to disable, this is a default behaviour.

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/POCardTokenizationConfiguration.kt
@@ -16,28 +16,32 @@ import com.processout.sdk.ui.shared.configuration.POCancellationConfiguration
 import kotlinx.parcelize.Parcelize
 
 /**
- * Defines card tokenization configuration.
+ * Card tokenization configuration.
  *
  * @param[title] Custom title.
- * @param[cvcRequired] Specifies whether the CVC field should be displayed. Default value is _true_.
- * @param[cardholderNameRequired] Specifies whether the cardholder name field should be displayed. Default value is _true_.
- * @param[cardScanner] Card scanner configuration. Use _null_ to hide, this is a default behaviour.
+ * @param[cardNumber] Card number field configuration.
+ * @param[expirationDate] Expiration date field configuration.
+ * @param[cvc] CVC field configuration. Set _null_ to hide.
+ * @param[cardholderName] Cardholder name field configuration. Set _null_ to hide.
+ * @param[cardScanner] Card scanner configuration. Set _null_ to hide, this is a default behaviour.
  * @param[preferredScheme] Preferred scheme selection configuration.
- * Shows scheme selection if co-scheme is available. Use _null_ to hide.
+ * Shows scheme selection if co-scheme is available. Set _null_ to hide.
  * @param[billingAddress] Allows to customize the collection of billing address.
  * @param[saving] Card saving configuration. Displays checkbox that allows to save the card details for future payments.
- * Use _null_ to hide, this is a default behaviour.
+ * Set _null_ to hide, this is a default behaviour.
  * @param[submitButton] Submit button configuration.
- * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
- * @param[bottomSheet] Specifies bottom sheet configuration. By default is [WrapContent] and non-expandable.
+ * @param[cancelButton] Cancel button configuration. Set _null_ to hide.
+ * @param[bottomSheet] Bottom sheet configuration.
  * @param[metadata] Metadata related to the card.
  * @param[style] Custom style.
  */
 @Parcelize
 data class POCardTokenizationConfiguration(
     val title: String? = null,
-    val cvcRequired: Boolean = true,
-    val cardholderNameRequired: Boolean = true,
+    val cardNumber: TextField = TextField(),
+    val expirationDate: TextField = TextField(),
+    val cvc: TextField? = TextField(),
+    val cardholderName: TextField? = TextField(),
     val cardScanner: CardScannerConfiguration? = null,
     val preferredScheme: PreferredSchemeConfiguration? = PreferredSchemeConfiguration(),
     val billingAddress: BillingAddressConfiguration = BillingAddressConfiguration(),
@@ -54,18 +58,18 @@ data class POCardTokenizationConfiguration(
 ) : Parcelable {
 
     /**
-     * Defines card tokenization configuration.
+     * Card tokenization configuration.
      *
      * @param[title] Custom title.
      * @param[cvcRequired] Specifies whether the CVC field should be displayed. Default value is _true_.
      * @param[cardholderNameRequired] Specifies whether the cardholder name field should be displayed. Default value is _true_.
-     * @param[cardScanner] Card scanner configuration. Use _null_ to hide, this is a default behaviour.
+     * @param[cardScanner] Card scanner configuration. Set _null_ to hide, this is a default behaviour.
      * @param[preferredScheme] Preferred scheme selection configuration.
-     * Shows scheme selection if co-scheme is available. Use _null_ to hide.
+     * Shows scheme selection if co-scheme is available. Set _null_ to hide.
      * @param[billingAddress] Allows to customize the collection of billing address.
      * @param[savingAllowed] Displays checkbox that allows to save the card details for future payments.
      * @param[submitButton] Submit button configuration.
-     * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
+     * @param[cancelButton] Cancel button configuration. Set _null_ to hide.
      * @param[bottomSheet] Specifies bottom sheet configuration. By default is [WrapContent] and non-expandable.
      * @param[metadata] Metadata related to the card.
      * @param[style] Custom style.
@@ -89,8 +93,10 @@ data class POCardTokenizationConfiguration(
         style: Style? = null
     ) : this(
         title = title,
-        cvcRequired = cvcRequired,
-        cardholderNameRequired = cardholderNameRequired,
+        cvc = if (cvcRequired) TextField() else null,
+        cardholderName = if (cardholderNameRequired) TextField() else null,
+        cardScanner = cardScanner,
+        preferredScheme = preferredScheme,
         billingAddress = billingAddress,
         saving = if (savingAllowed) SavingConfiguration() else null,
         submitButton = submitButton,
@@ -101,7 +107,7 @@ data class POCardTokenizationConfiguration(
     )
 
     /**
-     * Defines card tokenization configuration.
+     * Card tokenization configuration.
      *
      * @param[title] Custom title.
      * @param[cvcRequired] Specifies whether the CVC field should be displayed. Default value is _true_.
@@ -147,8 +153,8 @@ data class POCardTokenizationConfiguration(
     /**
      * Text field configuration.
      *
-     * @param[label] Text field label. Pass _null_ to use the default label.
-     * @param[contentDescription] Content description for accessibility. Pass _null_ to use the default text.
+     * @param[label] Text field label. Set _null_ to use the default label.
+     * @param[contentDescription] Content description for accessibility. Set _null_ to use the default text.
      */
     @Parcelize
     data class TextField(
@@ -157,7 +163,7 @@ data class POCardTokenizationConfiguration(
     ) : Parcelable
 
     /**
-     * Defines card scanner configuration.
+     * Card scanner configuration.
      *
      * @param[scanButton] Scan button configuration.
      * @param[configuration] Card scanner configuration.
@@ -171,7 +177,7 @@ data class POCardTokenizationConfiguration(
     /**
      * Preferred scheme selection configuration.
      *
-     * @param[title] Preferred scheme section title. Set _null_ to use a default value or empty string to remove the title.
+     * @param[title] Preferred scheme section title. Set _null_ to use the default value or set an empty string to remove the title.
      * @param[displayInline] Indicates whether selection field should be displayed inline. Default value is _true_.
      */
     @Parcelize
@@ -181,7 +187,7 @@ data class POCardTokenizationConfiguration(
     ) : Parcelable
 
     /**
-     * Defines billing address configuration.
+     * Billing address configuration.
      *
      * @param[mode] Defines how to collect the billing address. Default value is [CollectionMode.Automatic].
      * @param[countryCodes] Set of ISO country codes that is supported for the billing address. When _null_, all countries are provided.
@@ -228,8 +234,8 @@ data class POCardTokenizationConfiguration(
     /**
      * Button configuration.
      *
-     * @param[text] Button text. Pass _null_ to use the default text.
-     * @param[icon] Button icon drawable resource. Pass _null_ to hide.
+     * @param[text] Button text. Set _null_ to use the default text.
+     * @param[icon] Button icon drawable resource. Set _null_ to hide.
      */
     @Parcelize
     data class Button(
@@ -240,10 +246,10 @@ data class POCardTokenizationConfiguration(
     /**
      * Cancel button configuration.
      *
-     * @param[text] Button text. Pass _null_ to use the default text.
-     * @param[icon] Button icon drawable resource. Pass _null_ to hide.
+     * @param[text] Button text. Set _null_ to use the default text.
+     * @param[icon] Button icon drawable resource. Set _null_ to hide.
      * @param[confirmation] Specifies action confirmation configuration (e.g. dialog).
-     * Use _null_ to disable, this is a default behaviour.
+     * Set _null_ to disable, this is a default behaviour.
      */
     @Parcelize
     data class CancelButton(

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/component/POCardTokenizationViewComponent.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/component/POCardTokenizationViewComponent.kt
@@ -142,8 +142,10 @@ class POCardTokenizationViewComponent private constructor(
 
         private fun POCardTokenizationViewComponentConfiguration.map() =
             POCardTokenizationConfiguration(
-                cvcRequired = cvcRequired,
-                cardholderNameRequired = cardholderNameRequired,
+                cardNumber = cardNumber,
+                expirationDate = expirationDate,
+                cvc = cvc,
+                cardholderName = cardholderName,
                 cardScanner = cardScanner,
                 preferredScheme = preferredScheme,
                 billingAddress = billingAddress,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/component/POCardTokenizationViewComponentConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/card/tokenization/component/POCardTokenizationViewComponentConfiguration.kt
@@ -3,24 +3,28 @@ package com.processout.sdk.ui.card.tokenization.component
 import com.processout.sdk.ui.card.tokenization.POCardTokenizationConfiguration.*
 
 /**
- * Defines card tokenization view component configuration.
+ * Card tokenization view component configuration.
  *
- * @param[cvcRequired] Specifies whether the CVC field should be displayed. Default value is _true_.
- * @param[cardholderNameRequired] Specifies whether the cardholder name field should be displayed. Default value is _true_.
- * @param[cardScanner] Card scanner configuration. Use _null_ to hide, this is a default behaviour.
+ * @param[cardNumber] Card number field configuration.
+ * @param[expirationDate] Expiration date field configuration.
+ * @param[cvc] CVC field configuration. Set _null_ to hide.
+ * @param[cardholderName] Cardholder name field configuration. Set _null_ to hide.
+ * @param[cardScanner] Card scanner configuration. Set _null_ to hide, this is a default behaviour.
  * @param[preferredScheme] Preferred scheme selection configuration.
- * Shows scheme selection if co-scheme is available. Use _null_ to hide.
+ * Shows scheme selection if co-scheme is available. Set _null_ to hide.
  * @param[billingAddress] Allows to customize the collection of billing address.
  * @param[saving] Card saving configuration. Displays checkbox that allows to save the card details for future payments.
- * Use _null_ to hide, this is a default behaviour.
- * @param[submitButton] Submit button configuration. Use _null_ to hide.
- * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
+ * Set _null_ to hide, this is a default behaviour.
+ * @param[submitButton] Submit button configuration. Set _null_ to hide.
+ * @param[cancelButton] Cancel button configuration. Set _null_ to hide.
  * @param[metadata] Metadata related to the card.
- * @param[style] Allows to customize the look and feel.
+ * @param[style] Custom style.
  */
 data class POCardTokenizationViewComponentConfiguration(
-    val cvcRequired: Boolean = true,
-    val cardholderNameRequired: Boolean = true,
+    val cardNumber: TextField = TextField(),
+    val expirationDate: TextField = TextField(),
+    val cvc: TextField? = TextField(),
+    val cardholderName: TextField? = TextField(),
     val cardScanner: CardScannerConfiguration? = null,
     val preferredScheme: PreferredSchemeConfiguration? = PreferredSchemeConfiguration(),
     val billingAddress: BillingAddressConfiguration = BillingAddressConfiguration(),
@@ -32,19 +36,19 @@ data class POCardTokenizationViewComponentConfiguration(
 ) {
 
     /**
-     * Defines card tokenization view component configuration.
+     * Card tokenization view component configuration.
      *
      * @param[cvcRequired] Specifies whether the CVC field should be displayed. Default value is _true_.
      * @param[cardholderNameRequired] Specifies whether the cardholder name field should be displayed. Default value is _true_.
-     * @param[cardScanner] Card scanner configuration. Use _null_ to hide, this is a default behaviour.
+     * @param[cardScanner] Card scanner configuration. Set _null_ to hide, this is a default behaviour.
      * @param[preferredScheme] Preferred scheme selection configuration.
-     * Shows scheme selection if co-scheme is available. Use _null_ to hide.
+     * Shows scheme selection if co-scheme is available. Set _null_ to hide.
      * @param[billingAddress] Allows to customize the collection of billing address.
      * @param[savingAllowed] Displays checkbox that allows to save the card details for future payments.
-     * @param[submitButton] Submit button configuration. Use _null_ to hide.
-     * @param[cancelButton] Cancel button configuration. Use _null_ to hide.
+     * @param[submitButton] Submit button configuration. Set _null_ to hide.
+     * @param[cancelButton] Cancel button configuration. Set _null_ to hide.
      * @param[metadata] Metadata related to the card.
-     * @param[style] Allows to customize the look and feel.
+     * @param[style] Custom style.
      */
     @Deprecated(message = "Use alternative constructor.")
     constructor(
@@ -59,8 +63,8 @@ data class POCardTokenizationViewComponentConfiguration(
         metadata: Map<String, String>? = null,
         style: Style? = null
     ) : this(
-        cvcRequired = cvcRequired,
-        cardholderNameRequired = cardholderNameRequired,
+        cvc = if (cvcRequired) TextField() else null,
+        cardholderName = if (cardholderNameRequired) TextField() else null,
         cardScanner = cardScanner,
         preferredScheme = preferredScheme,
         billingAddress = billingAddress,

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/DynamicCheckoutInteractor.kt
@@ -500,8 +500,8 @@ internal class DynamicCheckoutInteractor(
 
     private fun POCardTokenizationConfiguration.apply(configuration: CardConfiguration) =
         copy(
-            cvcRequired = configuration.cvcRequired,
-            cardholderNameRequired = configuration.cardholderNameRequired,
+            cvc = if (configuration.cvcRequired) cvc else null,
+            cardholderName = if (configuration.cardholderNameRequired) cardholderName else null,
             preferredScheme = if (configuration.schemeSelectionAllowed) preferredScheme else null,
             billingAddress = billingAddress.copy(
                 mode = configuration.billingAddress.collectionMode.map(),

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutActivity.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutActivity.kt
@@ -43,6 +43,7 @@ import com.processout.sdk.ui.checkout.DynamicCheckoutSideEffect.*
 import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration.*
 import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration.Button
 import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration.CancelButton
+import com.processout.sdk.ui.checkout.PODynamicCheckoutConfiguration.CardConfiguration.TextField
 import com.processout.sdk.ui.core.annotation.ProcessOutInternalApi
 import com.processout.sdk.ui.core.theme.ProcessOutTheme
 import com.processout.sdk.ui.googlepay.POGooglePayCardTokenizationLauncher
@@ -97,6 +98,10 @@ class PODynamicCheckoutActivity : POBaseTransparentPortraitActivity() {
         val preferredScheme = configuration.card.preferredScheme
         val billingAddress = configuration.card.billingAddress
         return POCardTokenizationConfiguration(
+            cardNumber = configuration.card.cardNumber.map(),
+            expirationDate = configuration.card.expirationDate.map(),
+            cvc = configuration.card.cvc.map(),
+            cardholderName = configuration.card.cardholderName.map(),
             cardScanner = configuration.card.cardScanner?.let {
                 CardScannerConfiguration(
                     scanButton = POCardTokenizationConfiguration.Button(
@@ -136,6 +141,12 @@ class PODynamicCheckoutActivity : POBaseTransparentPortraitActivity() {
             metadata = configuration.card.metadata
         )
     }
+
+    private fun TextField.map() =
+        POCardTokenizationConfiguration.TextField(
+            label = label,
+            contentDescription = contentDescription
+        )
 
     private fun nativeAlternativePaymentConfiguration(): PONativeAlternativePaymentConfiguration {
         val returnUrl = configuration.alternativePayment.returnUrl

--- a/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
+++ b/ui/src/main/kotlin/com/processout/sdk/ui/checkout/PODynamicCheckoutConfiguration.kt
@@ -87,6 +87,10 @@ data class PODynamicCheckoutConfiguration(
     /**
      * Specifies card payment configuration.
      *
+     * @param[cardNumber] Card number field configuration.
+     * @param[expirationDate] Expiration date field configuration.
+     * @param[cvc] CVC field configuration.
+     * @param[cardholderName] Cardholder name field configuration.
      * @param[cardScanner] Card scanner configuration. Use _null_ to hide.
      * @param[preferredScheme] Preferred scheme selection configuration.
      * @param[billingAddress] Specifies billing address configuration.
@@ -94,11 +98,27 @@ data class PODynamicCheckoutConfiguration(
      */
     @Parcelize
     data class CardConfiguration(
+        val cardNumber: TextField = TextField(),
+        val expirationDate: TextField = TextField(),
+        val cvc: TextField = TextField(),
+        val cardholderName: TextField = TextField(),
         val cardScanner: CardScannerConfiguration? = CardScannerConfiguration(),
         val preferredScheme: PreferredSchemeConfiguration = PreferredSchemeConfiguration(),
         val billingAddress: BillingAddressConfiguration = BillingAddressConfiguration(),
         val metadata: Map<String, String>? = null
     ) : Parcelable {
+
+        /**
+         * Text field configuration.
+         *
+         * @param[label] Text field label. Set _null_ to use the default label.
+         * @param[contentDescription] Content description for accessibility. Set _null_ to use the default text.
+         */
+        @Parcelize
+        data class TextField(
+            val label: String? = null,
+            val contentDescription: String? = null
+        ) : Parcelable
 
         /**
          * Specifies card scanner configuration.


### PR DESCRIPTION
* Added and applied `TextField(label, contentDescription)` to the following configurations: `POCardTokenizationConfiguration` `POCardTokenizationViewComponentConfiguration` `PODynamicCheckoutConfiguration`
* Minor rename refactoring
* Updated KDoc

**Note:** Constructors of `POCardTokenizationConfiguration` and `POCardTokenizationViewComponentConfiguration` where already deprecated in the [previous unreleased PR](https://github.com/processout/processout-android/pull/389), so there is no breaking changes in updated constructors in this PR.